### PR TITLE
Add Quo module name and label overrides for all integrations

### DIFF
--- a/backend/src/api-modules/quo/defaultConfig.json
+++ b/backend/src/api-modules/quo/defaultConfig.json
@@ -1,6 +1,6 @@
 {
     "name": "quo",
-    "baseUrl": "https://api.openphone.com",
+    "baseUrl": "https://api.quo.com",
     "authType": "api-key",
     "description": "Quo API integration for calls, messages, contacts, and phone number management"
 }

--- a/backend/src/api-modules/quo/definition.js
+++ b/backend/src/api-modules/quo/definition.js
@@ -7,7 +7,7 @@ const Definition = {
     API: Api,
     getName: () => config.name,
     moduleName: config.name,
-    modelName: 'OpenPhone',
+    modelName: 'Quo',
     requiredAuthMethods: {
         getAuthorizationRequirements: (api) => {
             return {

--- a/backend/src/integrations/AttioIntegration.js
+++ b/backend/src/integrations/AttioIntegration.js
@@ -28,7 +28,17 @@ class AttioIntegration extends BaseCRMIntegration {
         },
         modules: {
             attio: { definition: attio.Definition },
-            quo: { definition: quo.Definition },
+            quo: {
+                definition: {
+                    ...quo.Definition,
+                    getName: () => 'quo-attio',
+                    moduleName: 'quo-attio',
+                    display: {
+                        ...(quo.Definition.display || {}),
+                        label: 'Quo (Attio)',
+                    },
+                }
+            },
         },
         routes: [
             {
@@ -315,7 +325,7 @@ class AttioIntegration extends BaseCRMIntegration {
         if (!process.env.BASE_URL) {
             throw new Error(
                 'BASE_URL environment variable is required for webhook setup. ' +
-                    'Please configure this in your deployment environment before enabling webhooks.',
+                'Please configure this in your deployment environment before enabling webhooks.',
             );
         }
 
@@ -635,7 +645,7 @@ class AttioIntegration extends BaseCRMIntegration {
 
             console.log(
                 `[Attio] Fetched ${persons.length} ${objectType} at offset ${cursor || 0}, ` +
-                    `hasMore=${!!nextCursor}`,
+                `hasMore=${!!nextCursor}`,
             );
 
             return {
@@ -1902,7 +1912,7 @@ Received:
             if (contacts.length === 0) {
                 throw new Error(
                     `No Attio contact found with phone number ${phoneNumber} (normalized: ${normalizedPhone}). ` +
-                        `Contact must exist in Attio to log activities.`,
+                    `Contact must exist in Attio to log activities.`,
                 );
             }
 
@@ -1923,7 +1933,7 @@ Received:
 
             throw new Error(
                 `Found ${contacts.length} contact(s) with phone ${normalizedPhone} in Attio, ` +
-                    `but none were synced from Attio to Quo. Only synced contacts can receive activity logs.`,
+                `but none were synced from Attio to Quo. Only synced contacts can receive activity logs.`,
             );
         } catch (error) {
             console.error(

--- a/backend/src/integrations/AttioIntegration.test.js
+++ b/backend/src/integrations/AttioIntegration.test.js
@@ -80,6 +80,20 @@ describe('AttioIntegration (Refactored)', () => {
             expect(AttioIntegration.Definition.display.label).toBe('Attio');
         });
 
+        it('should have quo module with correct name and label overrides', () => {
+            expect(AttioIntegration.Definition.modules.quo).toBeDefined();
+            expect(AttioIntegration.Definition.modules.quo.definition).toBeDefined();
+            
+            // Test name override
+            expect(AttioIntegration.Definition.modules.quo.definition.getName()).toBe('quo-attio');
+            expect(AttioIntegration.Definition.modules.quo.definition.moduleName).toBe('quo-attio');
+            
+            // Test label override (if display property exists)
+            if (AttioIntegration.Definition.modules.quo.definition.display) {
+                expect(AttioIntegration.Definition.modules.quo.definition.display.label).toBe('Quo (Attio)');
+            }
+        });
+
         it('should have correct CRMConfig', () => {
             expect(AttioIntegration.CRMConfig).toBeDefined();
             expect(AttioIntegration.CRMConfig.personObjectTypes).toHaveLength(

--- a/backend/src/integrations/AxisCareIntegration.js
+++ b/backend/src/integrations/AxisCareIntegration.js
@@ -28,7 +28,17 @@ class AxisCareIntegration extends BaseCRMIntegration {
         },
         modules: {
             axisCare: { definition: axisCare.Definition },
-            quo: { definition: quo.Definition },
+            quo: { 
+                definition: {
+                    ...quo.Definition,
+                    getName: () => 'quo-axisCare',
+                    moduleName: 'quo-axisCare',
+                    display: {
+                        ...(quo.Definition.display || {}),
+                        label: 'Quo (AxisCare)',
+                    },
+                }
+            },
         },
         routes: [
             {

--- a/backend/src/integrations/AxisCareIntegration.test.js
+++ b/backend/src/integrations/AxisCareIntegration.test.js
@@ -99,6 +99,20 @@ describe('AxisCareIntegration', () => {
             );
         });
 
+        it('should have quo module with correct name and label overrides', () => {
+            expect(AxisCareIntegration.Definition.modules.quo).toBeDefined();
+            expect(AxisCareIntegration.Definition.modules.quo.definition).toBeDefined();
+            
+            // Test name override
+            expect(AxisCareIntegration.Definition.modules.quo.definition.getName()).toBe('quo-axisCare');
+            expect(AxisCareIntegration.Definition.modules.quo.definition.moduleName).toBe('quo-axisCare');
+            
+            // Test label override (if display property exists)
+            if (AxisCareIntegration.Definition.modules.quo.definition.display) {
+                expect(AxisCareIntegration.Definition.modules.quo.definition.display.label).toBe('Quo (AxisCare)');
+            }
+        });
+
         it('should have correct CRMConfig', () => {
             expect(
                 AxisCareIntegration.CRMConfig.personObjectTypes,

--- a/backend/src/integrations/PipedriveIntegration.js
+++ b/backend/src/integrations/PipedriveIntegration.js
@@ -26,7 +26,17 @@ class PipedriveIntegration extends BaseCRMIntegration {
         },
         modules: {
             pipedrive: { definition: pipedrive.Definition },
-            quo: { definition: quo.Definition },
+            quo: { 
+                definition: {
+                    ...quo.Definition,
+                    getName: () => 'quo-pipedrive',
+                    moduleName: 'quo-pipedrive',
+                    display: {
+                        ...(quo.Definition.display || {}),
+                        label: 'Quo (Pipedrive)',
+                    },
+                }
+            },
         },
         webhooks: {
             enabled: true,

--- a/backend/src/integrations/PipedriveIntegration.test.js
+++ b/backend/src/integrations/PipedriveIntegration.test.js
@@ -83,6 +83,20 @@ describe('PipedriveIntegration (Refactored)', () => {
             );
         });
 
+        it('should have quo module with correct name and label overrides', () => {
+            expect(PipedriveIntegration.Definition.modules.quo).toBeDefined();
+            expect(PipedriveIntegration.Definition.modules.quo.definition).toBeDefined();
+            
+            // Test name override
+            expect(PipedriveIntegration.Definition.modules.quo.definition.getName()).toBe('quo-pipedrive');
+            expect(PipedriveIntegration.Definition.modules.quo.definition.moduleName).toBe('quo-pipedrive');
+            
+            // Test label override (if display property exists)
+            if (PipedriveIntegration.Definition.modules.quo.definition.display) {
+                expect(PipedriveIntegration.Definition.modules.quo.definition.display.label).toBe('Quo (Pipedrive)');
+            }
+        });
+
         it('should have correct CRMConfig', () => {
             expect(PipedriveIntegration.CRMConfig).toBeDefined();
             expect(

--- a/backend/src/integrations/ScalingTestIntegration.js
+++ b/backend/src/integrations/ScalingTestIntegration.js
@@ -24,7 +24,17 @@ class ScalingTestIntegration extends BaseCRMIntegration {
             icon: '',
         },
         modules: {
-            quo: { definition: QuoDefinition },
+            quo: { 
+                definition: {
+                    ...QuoDefinition,
+                    getName: () => 'quo-scalingtest',
+                    moduleName: 'quo-scalingtest',
+                    display: {
+                        ...(QuoDefinition.display || {}),
+                        label: 'Quo (Scaling Test)',
+                    },
+                }
+            },
             'scale-test': {
                 definition: crmScaleTest.Definition,
             },

--- a/backend/src/integrations/ScalingTestIntegration.refactored.test.js
+++ b/backend/src/integrations/ScalingTestIntegration.refactored.test.js
@@ -17,7 +17,7 @@ jest.mock('../base/BaseCRMIntegration', () => {
     };
 });
 
-const ScalingTestIntegration = require('./ScalingTestIntegration.refactored');
+const ScalingTestIntegration = require('./ScalingTestIntegration');
 
 describe('ScalingTestIntegration (Refactored)', () => {
     let integration;
@@ -34,6 +34,20 @@ describe('ScalingTestIntegration (Refactored)', () => {
             expect(ScalingTestIntegration.Definition.display.label).toBe(
                 'Scaling Test Integration',
             );
+        });
+
+        it('should have quo module with correct name and label overrides', () => {
+            expect(ScalingTestIntegration.Definition.modules.quo).toBeDefined();
+            expect(ScalingTestIntegration.Definition.modules.quo.definition).toBeDefined();
+            
+            // Test name override
+            expect(ScalingTestIntegration.Definition.modules.quo.definition.getName()).toBe('quo-scalingtest');
+            expect(ScalingTestIntegration.Definition.modules.quo.definition.moduleName).toBe('quo-scalingtest');
+            
+            // Test label override (if display property exists)
+            if (ScalingTestIntegration.Definition.modules.quo.definition.display) {
+                expect(ScalingTestIntegration.Definition.modules.quo.definition.display.label).toBe('Quo (Scaling Test)');
+            }
         });
 
         it('should have high-scale CRMConfig', () => {

--- a/backend/src/integrations/ZohoCRMIntegration.js
+++ b/backend/src/integrations/ZohoCRMIntegration.js
@@ -18,7 +18,17 @@ class ZohoCRMIntegration extends BaseCRMIntegration {
             icon: '',
         },
         modules: {
-            quo: { definition: QuoDefinition },
+            quo: { 
+                definition: {
+                    ...QuoDefinition,
+                    getName: () => 'quo-zohoCrm',
+                    moduleName: 'quo-zohoCrm',
+                    display: {
+                        ...(QuoDefinition.display || {}),
+                        label: 'Quo (Zoho CRM)',
+                    },
+                }
+            },
             zohoCrm: {
                 definition: zohoCrm.Definition,
             },

--- a/backend/src/integrations/ZohoCRMIntegration.test.js
+++ b/backend/src/integrations/ZohoCRMIntegration.test.js
@@ -39,7 +39,7 @@ jest.mock('../base/BaseCRMIntegration', () => {
     };
 });
 
-const ZohoCRMIntegration = require('./ZohoCRMIntegration.refactored');
+const ZohoCRMIntegration = require('./ZohoCRMIntegration');
 
 describe('ZohoCRMIntegration (Refactored)', () => {
     let integration;
@@ -96,6 +96,20 @@ describe('ZohoCRMIntegration (Refactored)', () => {
             expect(ZohoCRMIntegration.Definition.display.label).toBe(
                 'Zoho CRM',
             );
+        });
+
+        it('should have quo module with correct name and label overrides', () => {
+            expect(ZohoCRMIntegration.Definition.modules.quo).toBeDefined();
+            expect(ZohoCRMIntegration.Definition.modules.quo.definition).toBeDefined();
+            
+            // Test name override
+            expect(ZohoCRMIntegration.Definition.modules.quo.definition.getName()).toBe('quo-zohoCrm');
+            expect(ZohoCRMIntegration.Definition.modules.quo.definition.moduleName).toBe('quo-zohoCrm');
+            
+            // Test label override (if display property exists)
+            if (ZohoCRMIntegration.Definition.modules.quo.definition.display) {
+                expect(ZohoCRMIntegration.Definition.modules.quo.definition.display.label).toBe('Quo (Zoho CRM)');
+            }
         });
 
         it('should have correct CRMConfig', () => {


### PR DESCRIPTION
## Summary
This PR implements Quo API module name and label overrides across all integrations to provide better identification and context.

## Changes
- **Module Names**: Override quo module name to `quo-<integration>` format
  - `quo-attio`
  - `quo-axisCare`
  - `quo-pipedrive`
  - `quo-zohoCrm`
  - `quo-scalingtest`

- **Module Labels**: Override quo module label to `Quo (<Integration>)` format
  - `Quo (Attio)`
  - `Quo (AxisCare)`
  - `Quo (Pipedrive)`
  - `Quo (Zoho CRM)`
  - `Quo (Scaling Test)`

- **Configuration Updates**:
  - Updated quo module baseUrl from `api.openphone.com` to `api.quo.com`
  - Updated quo module modelName from `OpenPhone` to `Quo`

## Implementation Details
- Used object spread syntax to preserve all existing quo module properties
- Only overrides `getName()`, `moduleName`, and `display.label` fields
- Maintains backward compatibility with existing integrations

## Testing
✅ Implemented using TDD approach:
1. Added failing tests for all 5 integrations
2. Implemented the overrides
3. All tests pass successfully

Test coverage added for:
- AttioIntegration
- AxisCareIntegration
- PipedriveIntegration
- ZohoCRMIntegration
- ScalingTestIntegration

All 5 new tests verify:
- `getName()` returns correct override
- `moduleName` property is set correctly
- `display.label` shows integration context

## Files Changed
- 5 integration implementation files
- 5 integration test files
- 2 quo module configuration files

Total: 12 files changed, 133 insertions(+), 13 deletions(-)