### PR TITLE
fix(webhooks): handle OpenPhone multi-participant 400 and Zoho empty JSON responses

### DIFF
--- a/backend/src/base/services/QuoWebhookEventProcessor.js
+++ b/backend/src/base/services/QuoWebhookEventProcessor.js
@@ -330,7 +330,19 @@ class QuoWebhookEventProcessor {
      * @returns {Promise<Object|null>} Call object with voicemail merged, or null if not found
      */
     static async fetchCallWithVoicemail(quoApi, callId, logPrefix = '[QuoEventProcessor]') {
-        const fullCallResponse = await quoApi.getCall(callId);
+        let fullCallResponse;
+        try {
+            fullCallResponse = await quoApi.getCall(callId);
+        } catch (error) {
+            const statusCode = error.statusCode || error.response?.status;
+            if (statusCode === 400) {
+                console.warn(
+                    `${logPrefix} Cannot fetch call ${callId}: ${error.message?.split('\n')[0] || 'Bad Request'}`,
+                );
+                return null;
+            }
+            throw error;
+        }
         if (!fullCallResponse?.data) {
             return null;
         }

--- a/backend/src/integrations/ZohoCRMIntegration.js
+++ b/backend/src/integrations/ZohoCRMIntegration.js
@@ -2162,42 +2162,59 @@ class ZohoCRMIntegration extends BaseCRMIntegration {
     async _fetchZohoObject(objectType, recordId) {
         let person;
 
-        if (objectType === 'Contact') {
-            const response = await this.zoho.api.getContact(recordId);
+        try {
+            if (objectType === 'Contact') {
+                const response = await this.zoho.api.getContact(recordId);
 
-            if (!response.data) {
-                throw new Error(`No data returned for Contact ${recordId}`);
-            }
-
-            if (Array.isArray(response.data)) {
-                if (response.data.length === 0) {
+                if (!response.data) {
                     throw new Error(
-                        `Contact ${recordId} not found (empty array)`,
+                        `No data returned for Contact ${recordId}`,
                     );
                 }
-                person = response.data[0];
-            } else {
-                person = response.data;
-            }
-        } else if (objectType === 'Account') {
-            const response = await this.zoho.api.getAccount(recordId);
 
-            if (!response.data) {
-                throw new Error(`No data returned for Account ${recordId}`);
-            }
+                if (Array.isArray(response.data)) {
+                    if (response.data.length === 0) {
+                        throw new Error(
+                            `Contact ${recordId} not found (empty array)`,
+                        );
+                    }
+                    person = response.data[0];
+                } else {
+                    person = response.data;
+                }
+            } else if (objectType === 'Account') {
+                const response = await this.zoho.api.getAccount(recordId);
 
-            if (Array.isArray(response.data)) {
-                if (response.data.length === 0) {
+                if (!response.data) {
                     throw new Error(
-                        `Account ${recordId} not found (empty array)`,
+                        `No data returned for Account ${recordId}`,
                     );
                 }
-                person = response.data[0];
+
+                if (Array.isArray(response.data)) {
+                    if (response.data.length === 0) {
+                        throw new Error(
+                            `Account ${recordId} not found (empty array)`,
+                        );
+                    }
+                    person = response.data[0];
+                } else {
+                    person = response.data;
+                }
             } else {
-                person = response.data;
+                throw new Error(`Unknown object type: ${objectType}`);
             }
-        } else {
-            throw new Error(`Unknown object type: ${objectType}`);
+        } catch (error) {
+            if (
+                error?.message?.includes('Unexpected end of JSON input') ||
+                error?.message?.includes('invalid json response body')
+            ) {
+                console.warn(
+                    `[Zoho CRM] Empty response for ${objectType} ${recordId} (likely transient Zoho API issue), skipping sync`,
+                );
+                return null;
+            }
+            throw error;
         }
 
         if (!person) {
@@ -2252,6 +2269,12 @@ class ZohoCRMIntegration extends BaseCRMIntegration {
             }
 
             const person = await this._fetchZohoObject(objectType, recordId);
+            if (!person) {
+                console.log(
+                    `[Zoho CRM] Skipped ${objectType} ${recordId} — could not fetch from Zoho`,
+                );
+                return;
+            }
             const quoContact = await this.transformPersonToQuo(person);
 
             const result = await this.upsertContactToQuo(quoContact);

--- a/backend/test/QuoWebhookEventProcessor.MultiParticipant.test.js
+++ b/backend/test/QuoWebhookEventProcessor.MultiParticipant.test.js
@@ -1,0 +1,95 @@
+const QuoWebhookEventProcessor = require('../src/base/services/QuoWebhookEventProcessor');
+
+describe('QuoWebhookEventProcessor - Multi-Participant Call Handling', () => {
+    let mockQuoApi;
+
+    beforeEach(() => {
+        mockQuoApi = {
+            getCall: jest.fn(),
+            getCallVoicemails: jest.fn(),
+        };
+    });
+
+    describe('fetchCallWithVoicemail', () => {
+        it('should return null when OpenPhone returns 400 Too Many Participants', async () => {
+            const error = new Error('Too Many Participants');
+            error.statusCode = 400;
+            mockQuoApi.getCall.mockRejectedValue(error);
+
+            const result =
+                await QuoWebhookEventProcessor.fetchCallWithVoicemail(
+                    mockQuoApi,
+                    'call-123',
+                );
+
+            expect(result).toBeNull();
+        });
+
+        it('should log a warning for multi-participant calls instead of throwing', async () => {
+            const consoleSpy = jest
+                .spyOn(console, 'warn')
+                .mockImplementation();
+
+            const error = new Error('Too Many Participants');
+            error.statusCode = 400;
+            mockQuoApi.getCall.mockRejectedValue(error);
+
+            await QuoWebhookEventProcessor.fetchCallWithVoicemail(
+                mockQuoApi,
+                'call-456',
+            );
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.stringContaining('call-456'),
+            );
+            consoleSpy.mockRestore();
+        });
+
+        it('should re-throw non-400 errors from getCall', async () => {
+            const error = new Error('Internal Server Error');
+            error.statusCode = 500;
+            mockQuoApi.getCall.mockRejectedValue(error);
+
+            await expect(
+                QuoWebhookEventProcessor.fetchCallWithVoicemail(
+                    mockQuoApi,
+                    'call-789',
+                ),
+            ).rejects.toThrow('Internal Server Error');
+        });
+
+        it('should re-throw errors without statusCode (e.g. network errors)', async () => {
+            const error = new Error('ECONNREFUSED');
+            mockQuoApi.getCall.mockRejectedValue(error);
+
+            await expect(
+                QuoWebhookEventProcessor.fetchCallWithVoicemail(
+                    mockQuoApi,
+                    'call-net',
+                ),
+            ).rejects.toThrow('ECONNREFUSED');
+        });
+
+        it('should return call data normally when getCall succeeds', async () => {
+            mockQuoApi.getCall.mockResolvedValue({
+                data: {
+                    id: 'call-ok',
+                    status: 'completed',
+                    participants: [],
+                },
+            });
+
+            const result =
+                await QuoWebhookEventProcessor.fetchCallWithVoicemail(
+                    mockQuoApi,
+                    'call-ok',
+                );
+
+            expect(result).toEqual({
+                id: 'call-ok',
+                status: 'completed',
+                participants: [],
+            });
+        });
+    });
+});

--- a/backend/test/ZohoCRMIntegration.FetchZohoObject.test.js
+++ b/backend/test/ZohoCRMIntegration.FetchZohoObject.test.js
@@ -1,0 +1,121 @@
+const ZohoCRMIntegration = require('../src/integrations/ZohoCRMIntegration');
+
+describe('ZohoCRMIntegration - _fetchZohoObject JSON Error Handling', () => {
+    let integration;
+
+    beforeEach(() => {
+        integration = Object.create(ZohoCRMIntegration.prototype);
+        integration.zoho = {
+            api: {
+                getContact: jest.fn(),
+                getAccount: jest.fn(),
+            },
+        };
+    });
+
+    describe('when Zoho returns invalid JSON (empty body)', () => {
+        it('should return null for Contact when getContact throws invalid JSON error', async () => {
+            const jsonError = new Error(
+                'invalid json response body at https://www.zohoapis.com/crm/v8/Contacts/123 reason: Unexpected end of JSON input',
+            );
+            integration.zoho.api.getContact.mockRejectedValue(jsonError);
+
+            const result = await integration._fetchZohoObject(
+                'Contact',
+                '123',
+            );
+
+            expect(result).toBeNull();
+        });
+
+        it('should return null for Account when getAccount throws invalid JSON error', async () => {
+            const jsonError = new Error(
+                'invalid json response body at https://www.zohoapis.com/crm/v8/Accounts/456 reason: Unexpected end of JSON input',
+            );
+            integration.zoho.api.getAccount.mockRejectedValue(jsonError);
+
+            const result = await integration._fetchZohoObject(
+                'Account',
+                '456',
+            );
+
+            expect(result).toBeNull();
+        });
+
+        it('should log a warning when returning null due to invalid JSON', async () => {
+            const consoleSpy = jest
+                .spyOn(console, 'warn')
+                .mockImplementation();
+
+            const jsonError = new Error(
+                'invalid json response body reason: Unexpected end of JSON input',
+            );
+            integration.zoho.api.getContact.mockRejectedValue(jsonError);
+
+            await integration._fetchZohoObject('Contact', '789');
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.stringContaining('789'),
+            );
+            consoleSpy.mockRestore();
+        });
+    });
+
+    describe('when Zoho returns other errors', () => {
+        it('should re-throw non-JSON errors for Contact', async () => {
+            const error = new Error('Unauthorized');
+            error.statusCode = 401;
+            integration.zoho.api.getContact.mockRejectedValue(error);
+
+            await expect(
+                integration._fetchZohoObject('Contact', '123'),
+            ).rejects.toThrow('Unauthorized');
+        });
+
+        it('should re-throw non-JSON errors for Account', async () => {
+            const error = new Error('Rate limit exceeded');
+            error.statusCode = 429;
+            integration.zoho.api.getAccount.mockRejectedValue(error);
+
+            await expect(
+                integration._fetchZohoObject('Account', '456'),
+            ).rejects.toThrow('Rate limit exceeded');
+        });
+    });
+
+    describe('when Zoho returns valid data', () => {
+        it('should return contact data normally', async () => {
+            integration.zoho.api.getContact.mockResolvedValue({
+                data: [{ id: '123', Full_Name: 'John Doe' }],
+            });
+
+            const result = await integration._fetchZohoObject(
+                'Contact',
+                '123',
+            );
+
+            expect(result).toEqual({
+                id: '123',
+                Full_Name: 'John Doe',
+                _objectType: 'Contact',
+            });
+        });
+
+        it('should return account data normally', async () => {
+            integration.zoho.api.getAccount.mockResolvedValue({
+                data: [{ id: '456', Account_Name: 'Acme Corp' }],
+            });
+
+            const result = await integration._fetchZohoObject(
+                'Account',
+                '456',
+            );
+
+            expect(result).toEqual({
+                id: '456',
+                Account_Name: 'Acme Corp',
+                _objectType: 'Account',
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fixes two high-volume production errors found during daily error monitoring (2026-04-07):

- **OpenPhone Multi-Participant Calls (~128 errors/day)**: `fetchCallWithVoicemail` in `QuoWebhookEventProcessor` now catches 400 "Too Many Participants" errors from the OpenPhone API and returns `null` (gracefully skipping the call) instead of crashing the webhook handler. Only 400 errors are caught — other status codes and network errors are still re-thrown.

- **Zoho Invalid JSON Responses (~30 errors/day)**: `_fetchZohoObject` in `ZohoCRMIntegration` now catches "invalid json response body" / "Unexpected end of JSON input" errors (caused by Zoho intermittently returning empty response bodies) and returns `null`. The `_syncPersonToQuo` caller handles the null by logging and skipping the sync. This matches the existing pattern already used in `fetchPersonPage`.

### Other Errors Observed (not fixed here)
- **Attio/Pipedrive dead OAuth tokens** — known issue, requires user re-auth
- **Zoho webhook renewal "NOT_SUBSCRIBED"** for integration 5249 — known issue
- **DLQ FETCH_PERSON_PAGE with null integrationId** (7 msgs) — `QueueManager.queueFetchPersonPage()` doesn't include `integrationId` in message payload, making DLQ processing lose context. Structural fix deferred.

## Test plan
- [x] TDD: Red-green tests for `fetchCallWithVoicemail` 400 handling (5 tests)
- [x] TDD: Red-green tests for `_fetchZohoObject` JSON error handling (7 tests)
- [x] Full test suite: no new regressions (pre-existing Attio timeout failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)