### PR TITLE
fix(zoho): fall back to phone param search on 400 Bad Request

### DIFF
--- a/backend/src/integrations/ZohoCRMIntegration.js
+++ b/backend/src/integrations/ZohoCRMIntegration.js
@@ -1603,9 +1603,12 @@ class ZohoCRMIntegration extends BaseCRMIntegration {
             }
             return null;
         } catch (error) {
-            if (error.message?.includes('INVALID_QUERY')) {
+            if (
+                error.message?.includes('INVALID_QUERY') ||
+                error.statusCode === 400
+            ) {
                 console.warn(
-                    `[Quo Webhook] Criteria search not supported for Phone/Mobile fields, falling back to phone param search`,
+                    `[Quo Webhook] Criteria search failed (${error.statusCode || 'INVALID_QUERY'}), falling back to phone param search`,
                 );
                 return this._findZohoContactByPhoneParam(normalizedPhone);
             }

--- a/backend/src/integrations/ZohoCRMIntegration.test.js
+++ b/backend/src/integrations/ZohoCRMIntegration.test.js
@@ -999,6 +999,38 @@ describe('ZohoCRMIntegration (Refactored)', () => {
             expect(result).toBeNull();
         });
 
+        it('should fall back to phone param when criteria search returns 400 Bad Request', async () => {
+            const fetchError = new Error(
+                '400 Bad Request on Contacts/search',
+            );
+            fetchError.statusCode = 400;
+
+            mockZohoCrm.api.searchContacts
+                .mockRejectedValueOnce(fetchError)
+                .mockResolvedValueOnce({
+                    data: [{ id: 'zoho-contact-789' }],
+                });
+
+            const consoleSpy = jest
+                .spyOn(console, 'warn')
+                .mockImplementation();
+
+            const result =
+                await integration._findZohoContactByPhone('+15550001111');
+
+            expect(result).toBe('zoho-contact-789');
+            expect(mockZohoCrm.api.searchContacts).toHaveBeenCalledTimes(2);
+            expect(mockZohoCrm.api.searchContacts).toHaveBeenNthCalledWith(
+                2,
+                { phone: '+15550001111' },
+            );
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.stringContaining('falling back to phone param search'),
+            );
+
+            consoleSpy.mockRestore();
+        });
+
         it('should re-throw transient errors to allow SQS retry', async () => {
             const originalError = new Error('500 Internal Server Error');
             mockZohoCrm.api.searchContacts.mockRejectedValue(originalError);


### PR DESCRIPTION
## Summary
- **Bug**: `_findZohoContactByPhone` only fell back to phone param search on `INVALID_QUERY` errors, but Zoho CRM instances (especially `.zohoapis.in` India DC) return generic `400 Bad Request` for unsupported criteria search formats
- **Impact**: Webhook processing (call events) failed entirely for affected Zoho customers instead of gracefully falling back to an alternative search method
- **Fix**: Extend fallback condition to also trigger on `error.statusCode === 400`, matching the same behavior as the existing `INVALID_QUERY` fallback

## Root Cause
Production logs (2026-04-08) show a Zoho India DC customer hitting:
```
GET https://www.zohoapis.in/crm/v8/Contacts/search?fields=...&criteria=((Phone:equals:+14379916724)or(Mobile:equals:+14379916724))
400 Bad Request
```

The FetchError has `statusCode: 400` but the error message doesn't contain `INVALID_QUERY`, so the existing fallback at line 1606 was not triggered. The error propagated up and crashed the webhook handler.

## Test plan
- [x] Added test: `should fall back to phone param when criteria search returns 400 Bad Request`
- [x] Verified existing `INVALID_QUERY` fallback test still passes
- [x] Verified transient errors (500) are still re-thrown for SQS retry
- [x] All 36 Zoho tests pass
- [x] BaseCRM tests pass (78 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)