### PR TITLE
fix(zoho): use phone param search instead of criteria for contact lookup

### DIFF
--- a/backend/src/integrations/ZohoCRMIntegration.js
+++ b/backend/src/integrations/ZohoCRMIntegration.js
@@ -1591,49 +1591,14 @@ class ZohoCRMIntegration extends BaseCRMIntegration {
     async _findZohoContactByPhone(phoneNumber) {
         const normalizedPhone = this._normalizePhoneNumber(phoneNumber);
 
-        try {
-            const searchCriteria = `((Phone:equals:${normalizedPhone})or(Mobile:equals:${normalizedPhone}))`;
+        const searchResults = await this.zoho.api.searchContacts({
+            phone: normalizedPhone,
+        });
 
-            const searchResults = await this.zoho.api.searchContacts({
-                criteria: searchCriteria,
-            });
-
-            if (searchResults?.data?.length > 0) {
-                return searchResults.data[0].id;
-            }
-            return null;
-        } catch (error) {
-            if (error.message?.includes('INVALID_QUERY')) {
-                console.warn(
-                    `[Quo Webhook] Criteria search not supported for Phone/Mobile fields, falling back to phone param search`,
-                );
-                return this._findZohoContactByPhoneParam(normalizedPhone);
-            }
-            throw error;
+        if (searchResults?.data?.length > 0) {
+            return searchResults.data[0].id;
         }
-    }
-
-    /**
-     * Fallback search using Zoho's native `phone` query parameter.
-     * Used when criteria-based search fails because Phone/Mobile fields
-     * are not available for search in the customer's Zoho CRM instance.
-     * @private
-     * @param {string} normalizedPhone - Normalized phone number to search for
-     * @returns {Promise<string|null>} Zoho CRM record ID or null if not found
-     */
-    async _findZohoContactByPhoneParam(normalizedPhone) {
-        try {
-            const searchResults = await this.zoho.api.searchContacts({
-                phone: normalizedPhone,
-            });
-
-            if (searchResults?.data?.length > 0) {
-                return searchResults.data[0].id;
-            }
-            return null;
-        } catch (error) {
-            throw error;
-        }
+        return null;
     }
 
     /**

--- a/backend/src/integrations/ZohoCRMIntegration.test.js
+++ b/backend/src/integrations/ZohoCRMIntegration.test.js
@@ -933,7 +933,7 @@ describe('ZohoCRMIntegration (Refactored)', () => {
                 .mockReturnValue('+15550001111');
         });
 
-        it('should return contact ID when criteria search succeeds', async () => {
+        it('should search using phone param directly', async () => {
             mockZohoCrm.api.searchContacts.mockResolvedValue({
                 data: [{ id: 'zoho-contact-123' }],
             });
@@ -942,9 +942,9 @@ describe('ZohoCRMIntegration (Refactored)', () => {
                 await integration._findZohoContactByPhone('+15550001111');
 
             expect(result).toBe('zoho-contact-123');
+            expect(mockZohoCrm.api.searchContacts).toHaveBeenCalledTimes(1);
             expect(mockZohoCrm.api.searchContacts).toHaveBeenCalledWith({
-                criteria:
-                    '((Phone:equals:+15550001111)or(Mobile:equals:+15550001111))',
+                phone: '+15550001111',
             });
         });
 
@@ -959,39 +959,10 @@ describe('ZohoCRMIntegration (Refactored)', () => {
             expect(result).toBeNull();
         });
 
-        it('should fall back to phone param when INVALID_QUERY error occurs', async () => {
-            mockZohoCrm.api.searchContacts
-                .mockRejectedValueOnce(
-                    new Error(
-                        'INVALID_QUERY: the field is not available for search',
-                    ),
-                )
-                .mockResolvedValueOnce({
-                    data: [{ id: 'zoho-contact-456' }],
-                });
-
-            const result =
-                await integration._findZohoContactByPhone('+15550001111');
-
-            expect(result).toBe('zoho-contact-456');
-            expect(mockZohoCrm.api.searchContacts).toHaveBeenCalledTimes(2);
-            expect(mockZohoCrm.api.searchContacts).toHaveBeenNthCalledWith(1, {
-                criteria:
-                    '((Phone:equals:+15550001111)or(Mobile:equals:+15550001111))',
+        it('should return null when searchContacts returns empty data', async () => {
+            mockZohoCrm.api.searchContacts.mockResolvedValue({
+                data: null,
             });
-            expect(mockZohoCrm.api.searchContacts).toHaveBeenNthCalledWith(2, {
-                phone: '+15550001111',
-            });
-        });
-
-        it('should return null when phone param fallback also finds nothing', async () => {
-            mockZohoCrm.api.searchContacts
-                .mockRejectedValueOnce(
-                    new Error(
-                        'INVALID_QUERY: the field is not available for search',
-                    ),
-                )
-                .mockResolvedValueOnce({ data: [] });
 
             const result =
                 await integration._findZohoContactByPhone('+15550001111');
@@ -999,28 +970,13 @@ describe('ZohoCRMIntegration (Refactored)', () => {
             expect(result).toBeNull();
         });
 
-        it('should re-throw transient errors to allow SQS retry', async () => {
+        it('should re-throw errors to allow SQS retry', async () => {
             const originalError = new Error('500 Internal Server Error');
             mockZohoCrm.api.searchContacts.mockRejectedValue(originalError);
 
             await expect(
                 integration._findZohoContactByPhone('+15550001111'),
             ).rejects.toBe(originalError);
-        });
-
-        it('should re-throw when phone param fallback also fails', async () => {
-            const fallbackError = new Error('Network timeout');
-            mockZohoCrm.api.searchContacts
-                .mockRejectedValueOnce(
-                    new Error(
-                        'INVALID_QUERY: the field is not available for search',
-                    ),
-                )
-                .mockRejectedValueOnce(fallbackError);
-
-            await expect(
-                integration._findZohoContactByPhone('+15550001111'),
-            ).rejects.toBe(fallbackError);
         });
     });
 });


### PR DESCRIPTION
## Summary
- Replace criteria-based phone search (`Phone:equals:...`) with Zoho's native `phone` query parameter in `_findZohoContactByPhone`
- Remove the `_findZohoContactByPhoneParam` fallback method — no longer needed since `phone` param is now the primary (and only) method
- Net -92 lines, +13 lines — simpler, more robust

## Root Cause
The criteria search `((Phone:equals:+1...)or(Mobile:equals:+1...))` returns 400 on Zoho instances where Phone/Mobile fields are not configured for COQL search. Two failure modes:
1. Some instances return `INVALID_QUERY` in the response body → caught by existing fallback
2. Others return **empty-body 400** → `error.message` has no `INVALID_QUERY` text → fallback not triggered → webhook processing crashes

This affected **~6,300 errors/day** across all 4 Zoho datacenters (.com, .ca, .eu, .in).

## Why `phone` param is better
Validated against real Zoho CRM API with curl:

| Search method | Works on all instances? | Handles any format? | Single API call? |
|--------------|------------------------|--------------------|--------------------|
| `criteria` (Phone:equals:...) | ❌ Depends on field config | ❌ Parens in formatted numbers break syntax | Yes, but fails |
| `phone` param | ✅ Built-in, no field config needed | ✅ E.164, formatted, digits, partial | ✅ Yes |

Tested formats with `phone` param (all returned 200):
- `(407) 934-7639` — US formatted ✅
- `+14079347639` — E.164 ✅
- `4079347639` — digits only ✅
- `407-934-7639` — dashes ✅
- `9347639` — partial ✅
- Non-existent number → 204 (graceful empty) ✅

## Supersedes
This PR supersedes #69 (draft) which added `statusCode === 400` to the fallback condition. That approach added another catch condition to a fundamentally fragile strategy. This PR eliminates the problem entirely.

## Test plan
- [x] Updated tests: verify `searchContacts` called with `{ phone }` not `{ criteria }`
- [x] Added null data edge case test
- [x] Removed obsolete fallback/INVALID_QUERY tests
- [x] All 33 Zoho tests pass
- [x] All 78 BaseCRM tests pass
- [x] Full suite: 678 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)