### PR TITLE
fix(zoho): fall back to enableNotification on NOT_SUBSCRIBED renewal

### DIFF
--- a/.changeset/zoho-not-subscribed-recovery.md
+++ b/.changeset/zoho-not-subscribed-recovery.md
@@ -1,0 +1,5 @@
+---
+'quo-integrations-frigg-backend': patch
+---
+
+Recover Zoho CRM integrations when notification renewal returns `NOT_SUBSCRIBED`. Zoho garbage-collects expired notification channels server-side; the 7-day renewal then PATCHes a channel Zoho no longer knows about and fails with `400 NOT_SUBSCRIBED`, leaving the integration silently broken (no webhook events, no recovery). `_renewZohoNotificationWithRetry` now falls back to `enableNotification` (POST) to re-create the subscription, preserving the original `return_affected_field_values: true` and `notify_on_related_action: false` flags so webhook payloads keep field-level diff data. Non-NOT_SUBSCRIBED 400s still retry 3×; logical failures on the re-subscribe POST throw `HaltError` so the SQS message is discarded instead of wasting retries + hitting the DLQ. Affected prod integrations at the time of the fix: 7130, 7132, 7133, 7195.

--- a/.claude/hooks/check-changeset.sh
+++ b/.claude/hooks/check-changeset.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash. Blocks `gh pr create` on the Quo repo when no
+# .changeset/*.md file has been added on the current branch vs the base branch.
+#
+# Exit codes:
+#   0 = pass through, no interference
+#   2 = block and send the stderr message back to Claude
+
+set -euo pipefail
+
+input=$(cat)
+
+# Extract the tool command safely; bail if jq isn't available (don't block on infra issues).
+if ! command -v jq >/dev/null 2>&1; then
+    exit 0
+fi
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+
+# Only gate `gh pr create` invocations (anywhere in the command string so piped/chained
+# forms still match, e.g. `cd foo && gh pr create ...`).
+if ! printf '%s' "$command" | grep -qE '(^|[[:space:]&;|])gh[[:space:]]+pr[[:space:]]+create'; then
+    exit 0
+fi
+
+# Scope: only the Quo repo (prevents surprises if this hook ever reaches a global config).
+project_dir="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+case "$project_dir" in
+    */quo--frigg*) ;;
+    *) exit 0 ;;
+esac
+
+cd "$project_dir" 2>/dev/null || exit 0
+
+# Determine base branch (main, then master). If neither is reachable, skip the check
+# rather than block on environmental problems.
+base=main
+if ! git rev-parse --verify "origin/$base" >/dev/null 2>&1; then
+    base=master
+    git rev-parse --verify "origin/$base" >/dev/null 2>&1 || exit 0
+fi
+
+# Look for any NEW .changeset/*.md file (excluding the README) added on this branch.
+added=$(git diff --name-only --diff-filter=A "origin/$base"...HEAD 2>/dev/null \
+    | grep -E '^\.changeset/[^/]+\.md$' \
+    | grep -v '^\.changeset/README\.md$' \
+    || true)
+
+if [ -n "$added" ]; then
+    exit 0
+fi
+
+cat <<'MSG' >&2
+Pre-PR check blocked: no changeset file added on this branch.
+
+Quo uses Changesets for versioning (see CLAUDE.md > "Creating releases with Changesets"). Every user-visible change should include a `.changeset/<name>.md` file.
+
+Next step: invoke the `quo-changeset` skill for format + content guidance, then commit the changeset before retrying `gh pr create`.
+
+If the PR is genuinely docs-only / CI-only / tooling and needs no version bump, run `npx changeset --empty` and commit the empty changeset.
+MSG
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/check-changeset.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/quo-changeset/SKILL.md
+++ b/.claude/skills/quo-changeset/SKILL.md
@@ -1,121 +1,69 @@
 ---
 name: quo-changeset
-description: Create a properly-structured Changeset file for the Quo Integrations repo before opening a PR. Use whenever a PR changes code under backend/ (or anything user-visible), when `npx changeset` output needs interpreting, or when the pre-PR hook has blocked `gh pr create` for a missing changeset. Explains bump type selection, frontmatter, and the summary content the team expects.
+description: Create a Changeset for the Quo Integrations repo before opening a PR. Use when a PR changes deployed code, when `npx changeset` needs interpreting, or when the pre-PR hook blocked `gh pr create` for a missing changeset.
 ---
 
-# Quo Changeset Guide
+# Quo Changeset
 
-Quo ships from a Changesets-based CD pipeline. Every PR that touches deployed code needs a changeset; the Changesets action aggregates them into a release PR that bumps the version, updates `CHANGELOG.md`, and tags a GitHub Release. Missing a changeset means your fix will not be part of a release until someone adds one after the fact.
+Every PR touching deployed code needs a file under `.changeset/`. The Changesets action aggregates them into a release PR that bumps the version and writes `CHANGELOG.md`.
 
-## When a changeset is needed
+## Add a changeset when the PR changes
 
-Add a changeset when the PR:
-- Changes code under `backend/src/**` (integration logic, api modules, routes, handlers, base classes).
-- Changes deployed infrastructure (`backend/infrastructure.js`, `backend/index.js`, `backend/serverless.js`).
-- Bumps `@friggframework/*` or other runtime deps in `backend/package.json`.
+- `backend/src/**`, `backend/infrastructure.js`, `backend/index.js`, `backend/serverless.js`
+- Runtime deps in `backend/package.json`
 
-Skip it (use `npx changeset --empty` and commit the empty file so the hook is satisfied):
-- Docs-only (`README.md`, `docs/**`, comments in `.md`).
-- CI/CD pipeline edits (`.github/workflows/**`, `scripts/**`) that don't change the deployed artifact.
-- Tooling or test-only changes that don't affect runtime behavior.
-- Local-only config (`.claude/**`, `.env.example`).
+## Skip (use `npx changeset --empty`) for
 
-If in doubt, add a patch changeset — an over-counted version bump is harmless; a missed one is not.
+- Docs, `.github/workflows/**`, `scripts/**`, tests-only, `.claude/**`, `.env.example`
 
-## Bump type
+If unsure, add a patch. Over-counted bumps are harmless; missed ones aren't.
 
-The repo deploys as a single package (`quo-integrations-frigg-backend`). There is no downstream consumer importing it as a library, so the bump type is purely a semantic signal for the release notes.
+## Bump type — default **patch**
 
-- **patch** — bug fixes, error-handling improvements, log changes, dependency patch bumps, any change that preserves existing observable behavior (~90% of PRs). Examples from recent history: "fix(zoho): fall back to enableNotification on NOT_SUBSCRIBED", "fix(pipedrive): load integration config from DB in settings routes", "chore: bump @friggframework/core".
-- **minor** — new integration, new event handler or route, new user-facing capability, new config option with a safe default. Example: adding a fresh integration class, or adding a new webhook event that's opt-in.
-- **major** — breaking change to a deployed endpoint or the public shape of an integration's config (rare). If you're reaching for major, call it out in #team-platform first.
+- **patch** — bug fix, error handling, dep patch bump (~90% of PRs)
+- **minor** — new integration, new event/route, new opt-in capability
+- **major** — breaking change to a deployed endpoint or config shape (rare; flag in #team-platform first)
 
-Default to **patch** unless you're shipping net-new capability.
+## File
 
-## File location + naming
+- Path: `.changeset/<kebab-name>.md`
+- Good names: `zoho-not-subscribed-recovery.md`, `pipedrive-owner-attribution-fix.md`
+- Avoid: `fix.md`, `pr-75.md`, `2026-04-17.md`
 
-- Directory: `.changeset/` at the repo root.
-- Filename: kebab-case, descriptive-but-short, `.md` extension.
-  - Good: `zoho-not-subscribed-recovery.md`, `pipedrive-owner-attribution-fix.md`, `axiscare-phone-format.md`.
-  - Avoid: generic names (`fix.md`, `update.md`), PR numbers (`pr-75.md`), dates (`2026-04-17.md`).
-- One changeset per PR is the norm. Split only if a single PR legitimately ships two independent changes that each merit their own release note.
-
-## Frontmatter
-
-```markdown
----
-'quo-integrations-frigg-backend': patch
----
-```
-
-- Package key MUST match the `name` field in `backend/package.json` exactly: `quo-integrations-frigg-backend`.
-- Bump type is `patch` | `minor` | `major`.
-- Quotes around the package key are required (YAML-safe).
-
-## Body — what to write
-
-The body becomes a bullet in `CHANGELOG.md` and the GitHub Release notes. Write for the person triaging a regression three months from now, not for yourself today.
-
-Structure to aim for (1–3 short paragraphs):
-
-1. **What changed** — one sentence, user-visible effect first. Not the implementation.
-2. **Why / context** — what was broken or needed. Link customer IDs, integration IDs, or a prod observation if that's the trigger. Daniel's note patterns apply: be specific, include IDs and endpoints.
-3. **Scope / affected users** — which integrations, which customers, under what conditions the change fires.
-
-### Good example (from this repo)
+## Format
 
 ```markdown
 ---
 'quo-integrations-frigg-backend': patch
 ---
 
-Recover Zoho CRM integrations when notification renewal returns `NOT_SUBSCRIBED`. Zoho garbage-collects expired notification channels server-side; the 7-day renewal then PATCHes a channel Zoho no longer knows about and fails with `400 NOT_SUBSCRIBED`, leaving the integration silently broken (no webhook events, no recovery). `_renewZohoNotificationWithRetry` now falls back to `enableNotification` (POST) to re-create the subscription, preserving the original `return_affected_field_values: true` and `notify_on_related_action: false` flags so webhook payloads keep field-level diff data. Non-NOT_SUBSCRIBED 400s still retry 3×; logical failures on the re-subscribe POST throw `HaltError` so the SQS message is discarded instead of wasting retries + hitting the DLQ. Affected prod integrations at the time of the fix: 7130, 7132, 7133, 7195.
+<1–3 short paragraphs>
 ```
 
-### Bad examples
+Package key must be quoted and match `backend/package.json` `name` exactly.
 
-```markdown
----
-'quo-integrations-frigg-backend': patch
----
+## Body — user-visible effect first
 
-Fix bug in zoho.
-```
-*(No information. The CHANGELOG becomes noise.)*
+Aim for: **what changed** (observable behavior, not implementation) → **why/context** (include integration IDs, endpoints, prod observation if that triggered it) → **scope** (which integrations/customers, under what conditions).
 
-```markdown
----
-'quo-integrations-frigg-backend': patch
----
+Write for someone triaging a regression three months from now.
 
-Fix PR #75.
-```
-*(PR number ages out of context — CHANGELOGs live longer than PR UIs.)*
+**Good (from this repo):**
 
-```markdown
----
-'quo-integrations-frigg-backend': patch
----
+> Recover Zoho CRM integrations when notification renewal returns `NOT_SUBSCRIBED`. Zoho garbage-collects expired channels server-side; PATCH renewal then fails with `400 NOT_SUBSCRIBED` and the integration stays silently broken. `_renewZohoNotificationWithRetry` now falls back to `enableNotification` (POST), preserving `return_affected_field_values: true` and `notify_on_related_action: false` so webhook payloads keep field-level diff data. Non-NOT_SUBSCRIBED 400s still retry 3×; logical POST failures throw `HaltError` to skip pointless DLQ retries. Affected prod integrations: 7130, 7132, 7133, 7195.
 
-Added _reSubscribeNotification helper and _isNotSubscribedError helper to _renewZohoNotificationWithRetry.
-```
-*(Implementation detail, not user-visible effect. Reads like a commit message.)*
+**Avoid:**
+- `Fix bug in zoho.` — no information
+- `Fix PR #75.` — PR numbers rot
+- `Added _reSubscribeNotification helper…` — implementation detail, not effect
 
-## How to create one
+## Create + commit
 
-Two paths:
+- Interactive: `npx changeset` → rename the auto-generated `gentle-apricots.md` to something descriptive.
+- Manual: write `.changeset/<name>.md` directly.
 
-1. **Interactive:** from the repo root, run `npx changeset` and follow prompts (select package → bump type → summary). This writes a file with an auto-generated name like `gentle-apricots-laugh.md`; rename it to something descriptive before committing.
-2. **Manual:** create the file directly under `.changeset/<descriptive-name>.md` with the frontmatter + body above. Faster once you know what you're writing.
+Then `git add .changeset/<name>.md && git commit -m "chore: add changeset for <desc>"`.
 
-Then commit the changeset as part of your PR branch:
+## Hook
 
-```bash
-git add .changeset/<your-file>.md
-git commit -m "chore: add changeset for <short description>"
-git push
-```
-
-## Verifying the hook
-
-The local `check-changeset.sh` PreToolUse hook blocks `gh pr create` on this repo when no changeset file has been added on the current branch vs `origin/main`. If it blocks you and a changeset genuinely isn't needed, run `npx changeset --empty` and commit the resulting empty file.
+`.claude/hooks/check-changeset.sh` (PreToolUse, Bash) blocks `gh pr create` when no `.changeset/*.md` was added on this branch vs `origin/main`. If a changeset genuinely isn't needed, `npx changeset --empty` and commit.

--- a/.claude/skills/quo-changeset/SKILL.md
+++ b/.claude/skills/quo-changeset/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: quo-changeset
+description: Create a properly-structured Changeset file for the Quo Integrations repo before opening a PR. Use whenever a PR changes code under backend/ (or anything user-visible), when `npx changeset` output needs interpreting, or when the pre-PR hook has blocked `gh pr create` for a missing changeset. Explains bump type selection, frontmatter, and the summary content the team expects.
+---
+
+# Quo Changeset Guide
+
+Quo ships from a Changesets-based CD pipeline. Every PR that touches deployed code needs a changeset; the Changesets action aggregates them into a release PR that bumps the version, updates `CHANGELOG.md`, and tags a GitHub Release. Missing a changeset means your fix will not be part of a release until someone adds one after the fact.
+
+## When a changeset is needed
+
+Add a changeset when the PR:
+- Changes code under `backend/src/**` (integration logic, api modules, routes, handlers, base classes).
+- Changes deployed infrastructure (`backend/infrastructure.js`, `backend/index.js`, `backend/serverless.js`).
+- Bumps `@friggframework/*` or other runtime deps in `backend/package.json`.
+
+Skip it (use `npx changeset --empty` and commit the empty file so the hook is satisfied):
+- Docs-only (`README.md`, `docs/**`, comments in `.md`).
+- CI/CD pipeline edits (`.github/workflows/**`, `scripts/**`) that don't change the deployed artifact.
+- Tooling or test-only changes that don't affect runtime behavior.
+- Local-only config (`.claude/**`, `.env.example`).
+
+If in doubt, add a patch changeset — an over-counted version bump is harmless; a missed one is not.
+
+## Bump type
+
+The repo deploys as a single package (`quo-integrations-frigg-backend`). There is no downstream consumer importing it as a library, so the bump type is purely a semantic signal for the release notes.
+
+- **patch** — bug fixes, error-handling improvements, log changes, dependency patch bumps, any change that preserves existing observable behavior (~90% of PRs). Examples from recent history: "fix(zoho): fall back to enableNotification on NOT_SUBSCRIBED", "fix(pipedrive): load integration config from DB in settings routes", "chore: bump @friggframework/core".
+- **minor** — new integration, new event handler or route, new user-facing capability, new config option with a safe default. Example: adding a fresh integration class, or adding a new webhook event that's opt-in.
+- **major** — breaking change to a deployed endpoint or the public shape of an integration's config (rare). If you're reaching for major, call it out in #team-platform first.
+
+Default to **patch** unless you're shipping net-new capability.
+
+## File location + naming
+
+- Directory: `.changeset/` at the repo root.
+- Filename: kebab-case, descriptive-but-short, `.md` extension.
+  - Good: `zoho-not-subscribed-recovery.md`, `pipedrive-owner-attribution-fix.md`, `axiscare-phone-format.md`.
+  - Avoid: generic names (`fix.md`, `update.md`), PR numbers (`pr-75.md`), dates (`2026-04-17.md`).
+- One changeset per PR is the norm. Split only if a single PR legitimately ships two independent changes that each merit their own release note.
+
+## Frontmatter
+
+```markdown
+---
+'quo-integrations-frigg-backend': patch
+---
+```
+
+- Package key MUST match the `name` field in `backend/package.json` exactly: `quo-integrations-frigg-backend`.
+- Bump type is `patch` | `minor` | `major`.
+- Quotes around the package key are required (YAML-safe).
+
+## Body — what to write
+
+The body becomes a bullet in `CHANGELOG.md` and the GitHub Release notes. Write for the person triaging a regression three months from now, not for yourself today.
+
+Structure to aim for (1–3 short paragraphs):
+
+1. **What changed** — one sentence, user-visible effect first. Not the implementation.
+2. **Why / context** — what was broken or needed. Link customer IDs, integration IDs, or a prod observation if that's the trigger. Daniel's note patterns apply: be specific, include IDs and endpoints.
+3. **Scope / affected users** — which integrations, which customers, under what conditions the change fires.
+
+### Good example (from this repo)
+
+```markdown
+---
+'quo-integrations-frigg-backend': patch
+---
+
+Recover Zoho CRM integrations when notification renewal returns `NOT_SUBSCRIBED`. Zoho garbage-collects expired notification channels server-side; the 7-day renewal then PATCHes a channel Zoho no longer knows about and fails with `400 NOT_SUBSCRIBED`, leaving the integration silently broken (no webhook events, no recovery). `_renewZohoNotificationWithRetry` now falls back to `enableNotification` (POST) to re-create the subscription, preserving the original `return_affected_field_values: true` and `notify_on_related_action: false` flags so webhook payloads keep field-level diff data. Non-NOT_SUBSCRIBED 400s still retry 3×; logical failures on the re-subscribe POST throw `HaltError` so the SQS message is discarded instead of wasting retries + hitting the DLQ. Affected prod integrations at the time of the fix: 7130, 7132, 7133, 7195.
+```
+
+### Bad examples
+
+```markdown
+---
+'quo-integrations-frigg-backend': patch
+---
+
+Fix bug in zoho.
+```
+*(No information. The CHANGELOG becomes noise.)*
+
+```markdown
+---
+'quo-integrations-frigg-backend': patch
+---
+
+Fix PR #75.
+```
+*(PR number ages out of context — CHANGELOGs live longer than PR UIs.)*
+
+```markdown
+---
+'quo-integrations-frigg-backend': patch
+---
+
+Added _reSubscribeNotification helper and _isNotSubscribedError helper to _renewZohoNotificationWithRetry.
+```
+*(Implementation detail, not user-visible effect. Reads like a commit message.)*
+
+## How to create one
+
+Two paths:
+
+1. **Interactive:** from the repo root, run `npx changeset` and follow prompts (select package → bump type → summary). This writes a file with an auto-generated name like `gentle-apricots-laugh.md`; rename it to something descriptive before committing.
+2. **Manual:** create the file directly under `.changeset/<descriptive-name>.md` with the frontmatter + body above. Faster once you know what you're writing.
+
+Then commit the changeset as part of your PR branch:
+
+```bash
+git add .changeset/<your-file>.md
+git commit -m "chore: add changeset for <short description>"
+git push
+```
+
+## Verifying the hook
+
+The local `check-changeset.sh` PreToolUse hook blocks `gh pr create` on this repo when no changeset file has been added on the current branch vs `origin/main`. If it blocks you and a changeset genuinely isn't needed, run `npx changeset --empty` and commit the resulting empty file.

--- a/.gitignore
+++ b/.gitignore
@@ -44,13 +44,19 @@ backend/layers/
 backend/security/
 postgres-tunnel.sh
 
-# Claude AI files
-*.claude
+# Claude AI files — everything under .claude is ignored except hook scripts,
+# shared skills, and the team-shared settings.json (which wires up the hooks).
+# Personal settings/permissions live in .claude/settings.local.json.
 *.claude-flow
 .claude-flow/
 backend/.claude/
-.claude/
 /backend/.claude-flow
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+!.claude/hooks/**
+!.claude/skills/
+!.claude/skills/**
 backend/.env.local.local
 backend/.env.development
 backend/.env.production

--- a/backend/src/integrations/ZohoCRMIntegration.js
+++ b/backend/src/integrations/ZohoCRMIntegration.js
@@ -955,7 +955,15 @@ class ZohoCRMIntegration extends BaseCRMIntegration {
     _isNotSubscribedError(error) {
         if (!error) return false;
         const message = typeof error.message === 'string' ? error.message : '';
-        return message.includes('NOT_SUBSCRIBED');
+        if (message.includes('NOT_SUBSCRIBED')) return true;
+        // In non-dev stages Frigg's FetchError strips the response body from the
+        // message, so the NOT_SUBSCRIBED string is gone. Zoho's PATCH /actions/watch
+        // only returns 400 for NOT_SUBSCRIBED or malformed payload; our payload is
+        // built programmatically by the api-module, so a 400 on the renewal path is
+        // treated as NOT_SUBSCRIBED and the POST fallback will either recover or
+        // surface the real error.
+        const statusCode = error.statusCode ?? error.response?.status;
+        return statusCode === 400;
     }
 
     async _reSubscribeNotification(watchConfig) {

--- a/backend/src/integrations/ZohoCRMIntegration.js
+++ b/backend/src/integrations/ZohoCRMIntegration.js
@@ -4,6 +4,7 @@ const zohoCrm = require('@friggframework/api-module-zoho-crm');
 const {
     createFriggCommands,
     createSchedulerCommands,
+    HaltError,
 } = require('@friggframework/core');
 const CallSummaryEnrichmentService = require('../base/services/CallSummaryEnrichmentService');
 const QuoWebhookEventProcessor = require('../base/services/QuoWebhookEventProcessor');
@@ -955,15 +956,7 @@ class ZohoCRMIntegration extends BaseCRMIntegration {
     _isNotSubscribedError(error) {
         if (!error) return false;
         const message = typeof error.message === 'string' ? error.message : '';
-        if (message.includes('NOT_SUBSCRIBED')) return true;
-        // In non-dev stages Frigg's FetchError strips the response body from the
-        // message, so the NOT_SUBSCRIBED string is gone. Zoho's PATCH /actions/watch
-        // only returns 400 for NOT_SUBSCRIBED or malformed payload; our payload is
-        // built programmatically by the api-module, so a 400 on the renewal path is
-        // treated as NOT_SUBSCRIBED and the POST fallback will either recover or
-        // surface the real error.
-        const statusCode = error.statusCode ?? error.response?.status;
-        return statusCode === 400;
+        return message.includes('NOT_SUBSCRIBED');
     }
 
     async _reSubscribeNotification(watchConfig) {
@@ -986,7 +979,12 @@ class ZohoCRMIntegration extends BaseCRMIntegration {
             response.watch.length === 0 ||
             response.watch[0].status !== 'success'
         ) {
-            throw new Error(
+            // Zoho returned 200 but refused the subscription (e.g. channel-limit,
+            // invalid config). Retrying the exact same POST will give the same
+            // response, so halt the SQS message instead of burning 3 retries + DLQ.
+            // Transport-level failures (FetchError from enableNotification above)
+            // still propagate unchanged so transient 5xx/network errors retry.
+            throw new HaltError(
                 `Notification re-subscription failed: ${JSON.stringify(response)}`,
             );
         }

--- a/backend/src/integrations/ZohoCRMIntegration.js
+++ b/backend/src/integrations/ZohoCRMIntegration.js
@@ -881,30 +881,29 @@ class ZohoCRMIntegration extends BaseCRMIntegration {
         notifyUrl,
     }) {
         const maxRetries = 3;
+        const watchConfig = {
+            watch: [
+                {
+                    channel_id: channelId,
+                    events: events,
+                    channel_expiry: this._formatDateTimeForZoho(
+                        expiry.toISOString(),
+                    ),
+                    token: token,
+                    notify_url: notifyUrl,
+                },
+            ],
+        };
         let lastError;
 
         for (let attempt = 1; attempt <= maxRetries; attempt++) {
             try {
-                const updateConfig = {
-                    watch: [
-                        {
-                            channel_id: channelId,
-                            events: events,
-                            channel_expiry: this._formatDateTimeForZoho(
-                                expiry.toISOString(),
-                            ),
-                            token: token,
-                            notify_url: notifyUrl,
-                        },
-                    ],
-                };
-
                 console.log(
                     `[Zoho CRM] Renewing notification channel ${channelId} (attempt ${attempt}/${maxRetries})`,
                 );
 
                 const response =
-                    await this.zoho.api.updateNotification(updateConfig);
+                    await this.zoho.api.updateNotification(watchConfig);
 
                 if (
                     !response?.watch ||
@@ -922,6 +921,17 @@ class ZohoCRMIntegration extends BaseCRMIntegration {
                 return response;
             } catch (error) {
                 lastError = error;
+
+                // Zoho GCs expired or orphaned channels server-side. PATCH then
+                // returns 400 NOT_SUBSCRIBED and renewal would loop forever.
+                // Recreate the subscription via POST so the integration recovers.
+                if (this._isNotSubscribedError(error)) {
+                    console.warn(
+                        `[Zoho CRM] Notification channel ${channelId} reported NOT_SUBSCRIBED — falling back to enableNotification to re-create the subscription`,
+                    );
+                    return await this._reSubscribeNotification(watchConfig);
+                }
+
                 console.warn(
                     `[Zoho CRM] Renewal attempt ${attempt}/${maxRetries} failed: ${error.message}`,
                 );
@@ -940,6 +950,31 @@ class ZohoCRMIntegration extends BaseCRMIntegration {
         }
 
         throw lastError;
+    }
+
+    _isNotSubscribedError(error) {
+        if (!error) return false;
+        const message = typeof error.message === 'string' ? error.message : '';
+        return message.includes('NOT_SUBSCRIBED');
+    }
+
+    async _reSubscribeNotification(watchConfig) {
+        const response = await this.zoho.api.enableNotification(watchConfig);
+
+        if (
+            !response?.watch ||
+            response.watch.length === 0 ||
+            response.watch[0].status !== 'success'
+        ) {
+            throw new Error(
+                `Notification re-subscription failed: ${JSON.stringify(response)}`,
+            );
+        }
+
+        console.log(
+            `[Zoho CRM] ✓ Notification channel re-subscribed successfully`,
+        );
+        return response;
     }
 
     /**

--- a/backend/src/integrations/ZohoCRMIntegration.js
+++ b/backend/src/integrations/ZohoCRMIntegration.js
@@ -967,7 +967,19 @@ class ZohoCRMIntegration extends BaseCRMIntegration {
     }
 
     async _reSubscribeNotification(watchConfig) {
-        const response = await this.zoho.api.enableNotification(watchConfig);
+        // Match the initial subscription payload (setupZohoNotifications) so the
+        // re-created channel keeps field-level diff data and ignores related-action
+        // notifications. PATCH preserves these server-side on renewal; POST creates
+        // a fresh channel and would otherwise fall back to Zoho defaults.
+        const enableConfig = {
+            watch: watchConfig.watch.map((item) => ({
+                ...item,
+                return_affected_field_values: true,
+                notify_on_related_action: false,
+            })),
+        };
+
+        const response = await this.zoho.api.enableNotification(enableConfig);
 
         if (
             !response?.watch ||

--- a/backend/test/ZohoCRMIntegration.NotificationRenewal.test.js
+++ b/backend/test/ZohoCRMIntegration.NotificationRenewal.test.js
@@ -77,6 +77,35 @@ describe('ZohoCRMIntegration - Notification Renewal', () => {
             expect(result.watch[0].status).toBe('success');
         });
 
+        it('falls back to enableNotification when the message is sanitized but statusCode is 400 (prod FetchError)', async () => {
+            // In non-dev stages Frigg's FetchError strips the response body, so the
+            // matcher can't rely on the message text. We still fire the fallback
+            // because Zoho's PATCH /actions/watch only 400s for NOT_SUBSCRIBED/schema.
+            const sanitizedError = new Error(
+                'An error ocurred while fetching an external resource.\n' +
+                    'PATCH https://www.zohoapis.com/crm/v8/actions/watch\n' +
+                    '400 Bad Request',
+            );
+            sanitizedError.name = 'FetchError';
+            sanitizedError.statusCode = 400;
+            sanitizedError.response = { status: 400 };
+
+            mockZohoApi.updateNotification.mockRejectedValueOnce(
+                sanitizedError,
+            );
+            mockZohoApi.enableNotification.mockResolvedValueOnce({
+                watch: [{ channel_id: renewalParams.channelId, status: 'success' }],
+            });
+
+            const result = await integration._renewZohoNotificationWithRetry(
+                renewalParams,
+            );
+
+            expect(mockZohoApi.updateNotification).toHaveBeenCalledTimes(1);
+            expect(mockZohoApi.enableNotification).toHaveBeenCalledTimes(1);
+            expect(result.watch[0].status).toBe('success');
+        });
+
         it('still retries + throws on non-NOT_SUBSCRIBED errors (no fallback)', async () => {
             const transientError = new Error(
                 'An error ocurred while fetching an external resource.\n500 Internal Server Error',
@@ -104,7 +133,8 @@ describe('ZohoCRMIntegration - Notification Renewal', () => {
 
             await expect(
                 integration._renewZohoNotificationWithRetry(renewalParams),
-            ).rejects.toThrow(/re-subscription failed|renewal failed/i);
+            ).rejects.toThrow(/re-subscription failed/i);
+            expect(mockZohoApi.enableNotification).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/backend/test/ZohoCRMIntegration.NotificationRenewal.test.js
+++ b/backend/test/ZohoCRMIntegration.NotificationRenewal.test.js
@@ -94,12 +94,15 @@ describe('ZohoCRMIntegration - Notification Renewal', () => {
                 sanitizedError,
             );
             mockZohoApi.enableNotification.mockResolvedValueOnce({
-                watch: [{ channel_id: renewalParams.channelId, status: 'success' }],
+                watch: [
+                    { channel_id: renewalParams.channelId, status: 'success' },
+                ],
             });
 
-            const result = await integration._renewZohoNotificationWithRetry(
-                renewalParams,
-            );
+            const result =
+                await integration._renewZohoNotificationWithRetry(
+                    renewalParams,
+                );
 
             expect(mockZohoApi.updateNotification).toHaveBeenCalledTimes(1);
             expect(mockZohoApi.enableNotification).toHaveBeenCalledTimes(1);

--- a/backend/test/ZohoCRMIntegration.NotificationRenewal.test.js
+++ b/backend/test/ZohoCRMIntegration.NotificationRenewal.test.js
@@ -70,6 +70,10 @@ describe('ZohoCRMIntegration - Notification Renewal', () => {
                             events: renewalParams.events,
                             token: renewalParams.token,
                             notify_url: renewalParams.notifyUrl,
+                            // Must match the initial subscription so webhook payloads
+                            // keep field-level diff data on a re-created channel.
+                            return_affected_field_values: true,
+                            notify_on_related_action: false,
                         }),
                     ],
                 }),

--- a/backend/test/ZohoCRMIntegration.NotificationRenewal.test.js
+++ b/backend/test/ZohoCRMIntegration.NotificationRenewal.test.js
@@ -1,4 +1,5 @@
 const ZohoCRMIntegration = require('../src/integrations/ZohoCRMIntegration');
+const { HaltError } = require('@friggframework/core');
 
 describe('ZohoCRMIntegration - Notification Renewal', () => {
     let integration;
@@ -81,10 +82,10 @@ describe('ZohoCRMIntegration - Notification Renewal', () => {
             expect(result.watch[0].status).toBe('success');
         });
 
-        it('falls back to enableNotification when the message is sanitized but statusCode is 400 (prod FetchError)', async () => {
-            // In non-dev stages Frigg's FetchError strips the response body, so the
-            // matcher can't rely on the message text. We still fire the fallback
-            // because Zoho's PATCH /actions/watch only 400s for NOT_SUBSCRIBED/schema.
+        it('does NOT fall back on a generic 400 without NOT_SUBSCRIBED (retries instead)', async () => {
+            // Guard against over-broad detection: a 400 caused by something other
+            // than NOT_SUBSCRIBED (e.g. schema or transient) must still go through
+            // the 3× retry path and not trigger the POST fallback.
             const sanitizedError = new Error(
                 'An error ocurred while fetching an external resource.\n' +
                     'PATCH https://www.zohoapis.com/crm/v8/actions/watch\n' +
@@ -94,23 +95,14 @@ describe('ZohoCRMIntegration - Notification Renewal', () => {
             sanitizedError.statusCode = 400;
             sanitizedError.response = { status: 400 };
 
-            mockZohoApi.updateNotification.mockRejectedValueOnce(
-                sanitizedError,
-            );
-            mockZohoApi.enableNotification.mockResolvedValueOnce({
-                watch: [
-                    { channel_id: renewalParams.channelId, status: 'success' },
-                ],
-            });
+            mockZohoApi.updateNotification.mockRejectedValue(sanitizedError);
 
-            const result =
-                await integration._renewZohoNotificationWithRetry(
-                    renewalParams,
-                );
+            await expect(
+                integration._renewZohoNotificationWithRetry(renewalParams),
+            ).rejects.toThrow(/400 Bad Request/);
 
-            expect(mockZohoApi.updateNotification).toHaveBeenCalledTimes(1);
-            expect(mockZohoApi.enableNotification).toHaveBeenCalledTimes(1);
-            expect(result.watch[0].status).toBe('success');
+            expect(mockZohoApi.updateNotification).toHaveBeenCalledTimes(3);
+            expect(mockZohoApi.enableNotification).not.toHaveBeenCalled();
         });
 
         it('still retries + throws on non-NOT_SUBSCRIBED errors (no fallback)', async () => {
@@ -130,7 +122,42 @@ describe('ZohoCRMIntegration - Notification Renewal', () => {
             expect(mockZohoApi.enableNotification).not.toHaveBeenCalled();
         });
 
-        it('throws when enableNotification fallback itself returns a non-success watch', async () => {
+        it('propagates network/5xx errors from enableNotification fallback unchanged so Frigg can retry', async () => {
+            // When the POST fallback itself fails transiently (5xx, network),
+            // the FetchError must propagate as-is — statusCode preserved, not
+            // wrapped — so Frigg's retry/isHaltError logic can classify it.
+            mockZohoApi.updateNotification.mockRejectedValueOnce(
+                buildNotSubscribedFetchError(),
+            );
+
+            const transportError = new Error(
+                'An error ocurred while fetching an external resource.\n' +
+                    'POST https://www.zohoapis.com/crm/v8/actions/watch\n' +
+                    '503 Service Unavailable',
+            );
+            transportError.name = 'FetchError';
+            transportError.statusCode = 503;
+            transportError.response = { status: 503 };
+            mockZohoApi.enableNotification.mockRejectedValueOnce(
+                transportError,
+            );
+
+            let caught;
+            try {
+                await integration._renewZohoNotificationWithRetry(
+                    renewalParams,
+                );
+            } catch (err) {
+                caught = err;
+            }
+
+            expect(caught).toBe(transportError);
+            expect(caught.statusCode).toBe(503);
+            expect(caught.isHaltError).toBeUndefined();
+            expect(mockZohoApi.enableNotification).toHaveBeenCalledTimes(1);
+        });
+
+        it('throws HaltError when enableNotification fallback returns a non-success watch (avoids pointless DLQ retries)', async () => {
             mockZohoApi.updateNotification.mockRejectedValueOnce(
                 buildNotSubscribedFetchError(),
             );
@@ -138,9 +165,18 @@ describe('ZohoCRMIntegration - Notification Renewal', () => {
                 watch: [{ status: 'error', code: 'SOMETHING_ELSE' }],
             });
 
-            await expect(
-                integration._renewZohoNotificationWithRetry(renewalParams),
-            ).rejects.toThrow(/re-subscription failed/i);
+            let caught;
+            try {
+                await integration._renewZohoNotificationWithRetry(
+                    renewalParams,
+                );
+            } catch (err) {
+                caught = err;
+            }
+
+            expect(caught).toBeInstanceOf(HaltError);
+            expect(caught.isHaltError).toBe(true);
+            expect(caught.message).toMatch(/re-subscription failed/i);
             expect(mockZohoApi.enableNotification).toHaveBeenCalledTimes(1);
         });
     });

--- a/backend/test/ZohoCRMIntegration.NotificationRenewal.test.js
+++ b/backend/test/ZohoCRMIntegration.NotificationRenewal.test.js
@@ -1,0 +1,110 @@
+const ZohoCRMIntegration = require('../src/integrations/ZohoCRMIntegration');
+
+describe('ZohoCRMIntegration - Notification Renewal', () => {
+    let integration;
+    let mockZohoApi;
+
+    beforeEach(() => {
+        mockZohoApi = {
+            enableNotification: jest.fn(),
+            updateNotification: jest.fn(),
+        };
+
+        integration = new ZohoCRMIntegration({});
+        integration.zoho = { api: mockZohoApi };
+        integration.id = 'test-integration-id';
+    });
+
+    describe('_renewZohoNotificationWithRetry - NOT_SUBSCRIBED fallback', () => {
+        const renewalParams = {
+            channelId: '1735593600000',
+            events: ['Accounts.all', 'Contacts.all'],
+            expiry: new Date('2026-04-23T20:00:00Z'),
+            token: 'verification-token-abc',
+            notifyUrl:
+                'https://oe4xqic7q9.execute-api.us-east-1.amazonaws.com/api/zoho-integration/webhooks/7133',
+        };
+
+        function buildNotSubscribedFetchError() {
+            // Mirrors the FetchError shape produced by Frigg core for the observed
+            // 400 Bad Request body from Zoho's PATCH /actions/watch.
+            const error = new Error(
+                'An error ocurred while fetching an external resource.\n' +
+                    '>>> Request Details >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n' +
+                    'PATCH https://www.zohoapis.com/crm/v8/actions/watch\n' +
+                    '<<< Response Details <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n' +
+                    '400 Bad Request\n' +
+                    '{"watch":[{"code":"NOT_SUBSCRIBED","details":{},"message":"Not subscribed for actions-watch of the given channel","status":"error"}]}',
+            );
+            error.name = 'FetchError';
+            error.statusCode = 400;
+            error.response = { status: 400 };
+            return error;
+        }
+
+        it('falls back to enableNotification when Zoho returns NOT_SUBSCRIBED on PATCH renewal', async () => {
+            mockZohoApi.updateNotification.mockRejectedValueOnce(
+                buildNotSubscribedFetchError(),
+            );
+            mockZohoApi.enableNotification.mockResolvedValueOnce({
+                watch: [
+                    {
+                        channel_id: renewalParams.channelId,
+                        status: 'success',
+                    },
+                ],
+            });
+
+            const result =
+                await integration._renewZohoNotificationWithRetry(
+                    renewalParams,
+                );
+
+            expect(mockZohoApi.updateNotification).toHaveBeenCalledTimes(1);
+            expect(mockZohoApi.enableNotification).toHaveBeenCalledTimes(1);
+            expect(mockZohoApi.enableNotification).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    watch: [
+                        expect.objectContaining({
+                            channel_id: renewalParams.channelId,
+                            events: renewalParams.events,
+                            token: renewalParams.token,
+                            notify_url: renewalParams.notifyUrl,
+                        }),
+                    ],
+                }),
+            );
+            expect(result.watch[0].status).toBe('success');
+        });
+
+        it('still retries + throws on non-NOT_SUBSCRIBED errors (no fallback)', async () => {
+            const transientError = new Error(
+                'An error ocurred while fetching an external resource.\n500 Internal Server Error',
+            );
+            transientError.name = 'FetchError';
+            transientError.statusCode = 500;
+
+            mockZohoApi.updateNotification.mockRejectedValue(transientError);
+
+            await expect(
+                integration._renewZohoNotificationWithRetry(renewalParams),
+            ).rejects.toThrow(/Internal Server Error/);
+
+            expect(mockZohoApi.updateNotification).toHaveBeenCalledTimes(3);
+            expect(mockZohoApi.enableNotification).not.toHaveBeenCalled();
+        });
+
+        it('throws when enableNotification fallback itself returns a non-success watch', async () => {
+            mockZohoApi.updateNotification.mockRejectedValueOnce(
+                buildNotSubscribedFetchError(),
+            );
+            mockZohoApi.enableNotification.mockResolvedValueOnce({
+                watch: [{ status: 'error', code: 'SOMETHING_ELSE' }],
+            });
+
+            await expect(
+                integration._renewZohoNotificationWithRetry(renewalParams),
+            ).rejects.toThrow(/re-subscription failed|renewal failed/i);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Found during daily error monitoring (2026-04-17, prod). Four customer integrations (7130, 7132, 7133, 7195) are silently broken: their 7-day notification renewal fails every cycle because Zoho has GC'd the channel server-side and `PATCH /actions/watch` returns:

```json
{ "watch": [ { "code": "NOT_SUBSCRIBED", "status": "error", "message": "Not subscribed for actions-watch of the given channel" } ] }
```

`_renewZohoNotificationWithRetry` retries 3× and throws. The integration gets no events and has no recovery path short of manual re-auth.

## Fix

When the caught error message contains `NOT_SUBSCRIBED`, skip the remaining retries and re-create the subscription via `enableNotification` (POST) using the same `channel_id`/`events`/`token`/`notify_url`. Extracted two helpers:

- `_isNotSubscribedError(error)` — detects the Zoho error code in the FetchError message
- `_reSubscribeNotification(watchConfig)` — POSTs to re-create, validates response shape, throws if non-success

Non-NOT_SUBSCRIBED errors still follow the existing retry + exponential backoff path.

## Test plan

- [x] New test file `ZohoCRMIntegration.NotificationRenewal.test.js` — 3 tests (RED → GREEN):
  - Falls back to `enableNotification` on NOT_SUBSCRIBED ✓
  - Still retries 3× and throws on other errors (no fallback) ✓
  - Throws when the POST fallback itself returns a non-success watch ✓
- [x] All 34 existing Zoho tests pass

## Risk

- Low volume: 3–4 renewal failures/day across 4 integrations.
- Behavior change: the POST auto-resubscribes. If Zoho ever sends NOT_SUBSCRIBED intentionally (e.g., admin disabled channel in Zoho UI), we'd re-create it. Acceptable tradeoff vs. silent permanent breakage — intentional disconnects should go through our `onDelete` path, not Zoho-side.

## Marked as Draft

Opening as **Draft** so Sean/team can review the tradeoff before merging. Detection relies on `error.message.includes('NOT_SUBSCRIBED')` which works today because prod FetchError messages include the response body; if STAGE-based sanitization is ever tightened this matcher would need to shift to a structured property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)