### PR TITLE
fix(base): recover from 404 on update in upsertContactToQuo

### DIFF
--- a/.changeset/fix-upsert-404-recovery.md
+++ b/.changeset/fix-upsert-404-recovery.md
@@ -1,0 +1,7 @@
+---
+"quo-integrations-frigg-backend": patch
+---
+
+fix(base): recover from 404 on contact update by falling back to create
+
+When `upsertContactToQuo` finds a contact by externalId but the Quo API returns 404 on the PATCH (contact was deleted/archived), the method now falls back to the create path instead of throwing an unrecoverable error. This prevents silently discarding webhook-driven contact updates.

--- a/backend/src/base/BaseCRMIntegration.js
+++ b/backend/src/base/BaseCRMIntegration.js
@@ -1127,6 +1127,7 @@ class BaseCRMIntegration extends IntegrationBase {
      * This method implements the lookup-then-create/update pattern:
      * 1. Look up contact by externalId using listContacts
      * 2. If found, update using updateFriggContact
+     *    2a. On 404 (stale/deleted contact), fall back to create
      * 3. If not found, create using createFriggContact
      * 4. On 409 Conflict, attempt recovery via _recoverFrom409Conflict
      * 5. Store mapping by phone number

--- a/backend/src/base/BaseCRMIntegration.js
+++ b/backend/src/base/BaseCRMIntegration.js
@@ -1152,7 +1152,7 @@ class BaseCRMIntegration extends IntegrationBase {
             maxResults: 1,
         });
 
-        const existingContact =
+        let existingContact =
             existingContacts?.data?.length > 0
                 ? existingContacts.data[0]
                 : null;
@@ -1161,13 +1161,27 @@ class BaseCRMIntegration extends IntegrationBase {
         let action;
 
         if (existingContact) {
-            const response = await this.quo.api.updateFriggContact(
-                existingContact.id,
-                quoContact,
-            );
-            result = response.data;
-            action = 'updated';
-        } else {
+            try {
+                const response = await this.quo.api.updateFriggContact(
+                    existingContact.id,
+                    quoContact,
+                );
+                result = response.data;
+                action = 'updated';
+            } catch (error) {
+                if (error.statusCode === 404) {
+                    console.warn(
+                        `[upsertContactToQuo] 404 on update for externalId=${quoContact.externalId}`,
+                        `(quoContactId=${existingContact.id}), falling back to create`,
+                    );
+                    existingContact = null;
+                } else {
+                    throw error;
+                }
+            }
+        }
+
+        if (!existingContact && !result) {
             try {
                 const response =
                     await this.quo.api.createFriggContact(quoContact);

--- a/backend/src/base/BaseCRMIntegration.test.js
+++ b/backend/src/base/BaseCRMIntegration.test.js
@@ -1765,6 +1765,137 @@ describe('BaseCRMIntegration', () => {
             expect(result1.quoContactId).toBe('quo-created');
             expect(result2.quoContactId).toBe('quo-created');
         });
+        it('should fall back to create when update returns 404 (stale contact)', async () => {
+            const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+            const quoContact = {
+                externalId: 'crm-stale',
+                defaultFields: {
+                    firstName: 'Stale',
+                    lastName: 'Contact',
+                    phoneNumbers: [{ name: 'mobile', value: '+15557770000' }],
+                },
+            };
+
+            const notFoundError = new Error('Not Found');
+            notFoundError.statusCode = 404;
+
+            integration.quo.api.listContacts.mockResolvedValue({
+                data: [{ id: 'stale-quo-id', externalId: 'crm-stale' }],
+            });
+            integration.quo.api.updateFriggContact.mockRejectedValue(
+                notFoundError,
+            );
+            integration.quo.api.createFriggContact.mockResolvedValue({
+                data: {
+                    id: 'new-quo-id',
+                    externalId: 'crm-stale',
+                    defaultFields: {
+                        phoneNumbers: [
+                            { name: 'mobile', value: '+15557770000' },
+                        ],
+                    },
+                },
+            });
+
+            const result = await integration.upsertContactToQuo(quoContact);
+
+            expect(integration.quo.api.updateFriggContact).toHaveBeenCalledWith(
+                'stale-quo-id',
+                quoContact,
+            );
+            expect(
+                integration.quo.api.createFriggContact,
+            ).toHaveBeenCalledWith(quoContact);
+            expect(result).toEqual({
+                action: 'created',
+                quoContactId: 'new-quo-id',
+                externalId: 'crm-stale',
+            });
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.stringContaining('404 on update'),
+                expect.anything(),
+            );
+            consoleSpy.mockRestore();
+        });
+
+        it('should handle 404 on update followed by 409 on create (race condition)', async () => {
+            const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+            const quoContact = {
+                externalId: 'crm-404-then-409',
+                defaultFields: {
+                    firstName: 'DoubleConflict',
+                    phoneNumbers: [{ name: 'mobile', value: '+15557771111' }],
+                },
+            };
+
+            const notFoundError = new Error('Not Found');
+            notFoundError.statusCode = 404;
+            const conflictError = new Error('Conflict');
+            conflictError.statusCode = 409;
+
+            integration.quo.api.listContacts
+                .mockResolvedValueOnce({
+                    data: [
+                        { id: 'stale-id', externalId: 'crm-404-then-409' },
+                    ],
+                })
+                .mockResolvedValueOnce({
+                    data: [
+                        { id: 'recreated-id', externalId: 'crm-404-then-409' },
+                    ],
+                });
+            integration.quo.api.updateFriggContact
+                .mockRejectedValueOnce(notFoundError)
+                .mockResolvedValueOnce({
+                    data: {
+                        id: 'recreated-id',
+                        externalId: 'crm-404-then-409',
+                        defaultFields: {
+                            phoneNumbers: [
+                                { name: 'mobile', value: '+15557771111' },
+                            ],
+                        },
+                    },
+                });
+            integration.quo.api.createFriggContact.mockRejectedValue(
+                conflictError,
+            );
+
+            const result = await integration.upsertContactToQuo(quoContact);
+
+            expect(result).toEqual({
+                action: 'updated',
+                quoContactId: 'recreated-id',
+                externalId: 'crm-404-then-409',
+            });
+            consoleSpy.mockRestore();
+        });
+
+        it('should still throw non-404 update errors', async () => {
+            const quoContact = {
+                externalId: 'crm-500-update',
+                defaultFields: { firstName: 'ServerError' },
+            };
+
+            const serverError = new Error('Internal Server Error');
+            serverError.statusCode = 500;
+
+            integration.quo.api.listContacts.mockResolvedValue({
+                data: [{ id: 'existing-id', externalId: 'crm-500-update' }],
+            });
+            integration.quo.api.updateFriggContact.mockRejectedValue(
+                serverError,
+            );
+
+            await expect(
+                integration.upsertContactToQuo(quoContact),
+            ).rejects.toThrow('Internal Server Error');
+            expect(
+                integration.quo.api.createFriggContact,
+            ).not.toHaveBeenCalled();
+        });
     });
 
     describe('onUpdate - Configuration Updates', () => {

--- a/backend/src/base/BaseCRMIntegration.test.js
+++ b/backend/src/base/BaseCRMIntegration.test.js
@@ -1765,6 +1765,7 @@ describe('BaseCRMIntegration', () => {
             expect(result1.quoContactId).toBe('quo-created');
             expect(result2.quoContactId).toBe('quo-created');
         });
+
         it('should fall back to create when update returns 404 (stale contact)', async () => {
             const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
 


### PR DESCRIPTION
## Summary

- **Problem**: `upsertContactToQuo` finds a contact by `externalId` via `listContacts`, but the subsequent `PATCH` to `updateFriggContact` returns 404 (contact was deleted/archived in Quo). The 404 propagated uncaught, causing the webhook handler to fail and the message to be permanently discarded.
- **Impact**: 373 Attio contact updates silently dropped in the last 24 hours (spike of 290 in a 2-hour window at 22:00–23:00 UTC on 2026-04-17).
- **Fix**: Catch 404 on the update path and fall back to the create path (including existing 409 conflict recovery). Restructured from `if/else` to two consecutive `if` blocks — on 404, `existingContact` is cleared and the create block runs.

## Changes

- `BaseCRMIntegration.js`: Wrapped update call in try/catch, 404 clears `existingContact` and falls through to create block
- `BaseCRMIntegration.test.js`: Added 3 TDD tests:
  - 404 on update → falls back to create
  - 404 on update → 409 on create → 409 conflict recovery
  - Non-404 update errors still propagate

## Production Error Context

From CloudWatch `/aws/lambda/quo-integrations-prod-attioQueueWorker`:
```
[Attio] Failed to sync person:
  PATCH https://api.openphone.com/frigg/contact/694efef1c0cbe4898dbcba10
  → 404 Not Found
  at AttioIntegration.upsertContactToQuo (BaseCRMIntegration.js:1164)
[attio] Permanent 404 error for ON_WEBHOOK — message will be discarded (no retry)
```

## Test plan

- [x] TDD red-green-refactor cycle completed
- [x] 3 new tests pass (404 recovery, 404→409 race, non-404 still throws)
- [x] Full test suite: 46 suites, 1039 tests passing, 0 failures
- [x] Lint: 0 errors (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)