### PR TITLE
fix(analytics): add 5s timeout to prevent Lambda near-timeouts

### DIFF
--- a/.changeset/analytics-timeout.md
+++ b/.changeset/analytics-timeout.md
@@ -1,0 +1,10 @@
+---
+'quo-integrations-frigg': patch
+---
+
+fix(analytics): add 5s timeout to analytics tracking to prevent Lambda near-timeouts
+
+When the analytics API (integration.openphoneapi.com/v2/analytics) goes down, the
+`trackAnalyticsEvent` call would hang indefinitely, blocking Lambda execution for up to
+~289 seconds. This adds a 5-second timeout using Promise.race so analytics failures
+fail fast without impacting webhook processing.

--- a/backend/src/utils/trackAnalyticsEvent.js
+++ b/backend/src/utils/trackAnalyticsEvent.js
@@ -1,29 +1,16 @@
 /**
- * Track an analytics event to Quo's analytics API (fire-and-forget)
- *
- * This utility wraps the Quo API call to prevent analytics failures from blocking
- * business logic. All tracking is non-blocking and errors are logged but not thrown.
- *
- * The integration name is automatically derived from integration.constructor.Definition.name,
- * eliminating the need for manual string parameters and reducing copy-paste errors.
- *
- * @param {Object} integration - The integration instance
- * @param {Object} integration.constructor.Definition - Static Definition with name field
- * @param {string} integration.constructor.Definition.name - Integration name (e.g., 'attio')
- * @param {Object} integration.quo - Quo module with API instance
- * @param {Object} integration.quo.api - Quo API with sendAnalyticsEvent method
- * @param {Object} integration.commands - Commands object with findOrganizationUserById
- * @param {string} integration.userId - The user ID to look up
- * @param {string} event - Event type from QUO_ANALYTICS_EVENTS
- * @param {Object} [data={}] - Event-specific data (contactId, messageId, callId, error)
- * @returns {void}
+ * Track an analytics event to Quo's analytics API.
+ * Errors are logged but never thrown. Aborts after ANALYTICS_TIMEOUT_MS to prevent
+ * a slow/down analytics endpoint from blocking Lambda execution.
  */
+const ANALYTICS_TIMEOUT_MS = 5_000;
+
 async function trackAnalyticsEvent(integration, event, data = {}) {
     const integrationName = integration.constructor.Definition.name;
 
     if (!integration?.quo?.api || !integration?.commands) {
         console.warn(
-            `[Analytics][${integrationName}] Quo API or commands not available, skipping tracking`,
+            `[Analytics][${integrationName}] Quo API or commands not available, skipping tracking`
         );
         return;
     }
@@ -39,16 +26,16 @@ async function trackAnalyticsEvent(integration, event, data = {}) {
 
         if (!quoEntity) {
             console.warn(
-                `[Analytics][${integrationName}] No Quo entity found for user ${integration.userId}, skipping tracking`,
+                `[Analytics][${integrationName}] No Quo entity found for user ${integration.userId}, skipping tracking`
             );
             return;
         }
 
         const user = await integration.commands.findOrganizationUserById(
-            integration.userId,
+            integration.userId
         );
 
-        await integration.quo.api.sendAnalyticsEvent({
+        const analyticsCall = integration.quo.api.sendAnalyticsEvent({
             orgId: user?.appOrgId || null,
             userId: quoEntity.externalId || null,
             integration: integrationName,
@@ -56,10 +43,27 @@ async function trackAnalyticsEvent(integration, event, data = {}) {
             data,
         });
 
+        let timer;
+        const timeout = new Promise((_, reject) => {
+            timer = setTimeout(
+                () => reject(new Error('Analytics request timed out')),
+                ANALYTICS_TIMEOUT_MS
+            );
+        });
+
+        try {
+            await Promise.race([analyticsCall, timeout]);
+        } finally {
+            clearTimeout(timer);
+        }
+
         console.log(`[Analytics][${integrationName}] Tracked ${event}`);
     } catch (error) {
+        const msg = error.message.includes('timed out')
+            ? `timed out after ${ANALYTICS_TIMEOUT_MS}ms`
+            : error.message;
         console.warn(
-            `[Analytics][${integrationName}] Failed to track ${event}: ${error.message}`,
+            `[Analytics][${integrationName}] Failed to track ${event}: ${msg}`
         );
     }
 }

--- a/backend/src/utils/trackAnalyticsEvent.js
+++ b/backend/src/utils/trackAnalyticsEvent.js
@@ -43,6 +43,9 @@ async function trackAnalyticsEvent(integration, event, data = {}) {
             data,
         });
 
+        // Swallow late rejections if the timeout wins the race
+        analyticsCall.catch(() => {});
+
         let timer;
         const timeout = new Promise((_, reject) => {
             timer = setTimeout(
@@ -59,9 +62,9 @@ async function trackAnalyticsEvent(integration, event, data = {}) {
 
         console.log(`[Analytics][${integrationName}] Tracked ${event}`);
     } catch (error) {
-        const msg = error.message.includes('timed out')
+        const msg = error?.message?.includes('timed out')
             ? `timed out after ${ANALYTICS_TIMEOUT_MS}ms`
-            : error.message;
+            : error?.message || String(error);
         console.warn(
             `[Analytics][${integrationName}] Failed to track ${event}: ${msg}`
         );

--- a/backend/src/utils/trackAnalyticsEvent.test.js
+++ b/backend/src/utils/trackAnalyticsEvent.test.js
@@ -145,4 +145,43 @@ describe('trackAnalyticsEvent', () => {
 
         jest.useRealTimers();
     });
+
+    it('should not cause unhandled rejection when analytics rejects after timeout', async () => {
+        jest.useFakeTimers();
+
+        const unhandledRejections = [];
+        const handler = (reason) => unhandledRejections.push(reason);
+        process.on('unhandledRejection', handler);
+
+        const integration = createMockIntegration();
+        integration.quo.api.sendAnalyticsEvent.mockImplementation(
+            () =>
+                new Promise((_, reject) => {
+                    setTimeout(
+                        () => reject(new Error('502 Bad Gateway')),
+                        10_000
+                    );
+                })
+        );
+
+        const trackPromise = trackAnalyticsEvent(integration, 'ContactUpdated');
+
+        // Timeout fires at 5s
+        await jest.advanceTimersByTimeAsync(5_000);
+        await trackPromise;
+
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('timed out')
+        );
+
+        // Analytics call rejects at 10s (after timeout already won)
+        await jest.advanceTimersByTimeAsync(5_000);
+        // Flush microtasks so the late rejection propagates
+        await jest.advanceTimersByTimeAsync(0);
+
+        expect(unhandledRejections).toHaveLength(0);
+
+        process.removeListener('unhandledRejection', handler);
+        jest.useRealTimers();
+    });
 });

--- a/backend/src/utils/trackAnalyticsEvent.test.js
+++ b/backend/src/utils/trackAnalyticsEvent.test.js
@@ -1,0 +1,148 @@
+const { trackAnalyticsEvent } = require('./trackAnalyticsEvent');
+
+let warnSpy, logSpy;
+
+beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+});
+
+function createMockIntegration(overrides = {}) {
+    return {
+        constructor: {
+            Definition: {
+                name: 'test-integration',
+                modules: {
+                    quo: {
+                        definition: {
+                            getName: () => 'quo-module',
+                        },
+                    },
+                },
+            },
+        },
+        userId: 'user-123',
+        quo: {
+            api: {
+                sendAnalyticsEvent: jest.fn().mockResolvedValue({ ok: true }),
+            },
+        },
+        commands: {
+            findEntity: jest.fn().mockResolvedValue({
+                externalId: 'ext-456',
+            }),
+            findOrganizationUserById: jest.fn().mockResolvedValue({
+                appOrgId: 'org-789',
+            }),
+        },
+        ...overrides,
+    };
+}
+
+describe('trackAnalyticsEvent', () => {
+    it('should track an event successfully', async () => {
+        const integration = createMockIntegration();
+        await trackAnalyticsEvent(integration, 'ContactUpdated', {
+            contactId: '123',
+        });
+
+        expect(integration.quo.api.sendAnalyticsEvent).toHaveBeenCalledWith({
+            orgId: 'org-789',
+            userId: 'ext-456',
+            integration: 'test-integration',
+            event: 'ContactUpdated',
+            data: { contactId: '123' },
+        });
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.stringContaining('Tracked ContactUpdated')
+        );
+    });
+
+    it('should skip tracking when quo api is not available', async () => {
+        const integration = createMockIntegration({ quo: null });
+        await trackAnalyticsEvent(integration, 'ContactUpdated');
+
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('not available')
+        );
+    });
+
+    it('should skip tracking when no quo entity found', async () => {
+        const integration = createMockIntegration();
+        integration.commands.findEntity.mockResolvedValue(null);
+
+        await trackAnalyticsEvent(integration, 'ContactUpdated');
+
+        expect(integration.quo.api.sendAnalyticsEvent).not.toHaveBeenCalled();
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('No Quo entity')
+        );
+    });
+
+    it('should catch and log errors without throwing', async () => {
+        const integration = createMockIntegration();
+        integration.quo.api.sendAnalyticsEvent.mockRejectedValue(
+            new Error('502 Bad Gateway')
+        );
+
+        await trackAnalyticsEvent(integration, 'ContactUpdated');
+
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('Failed to track')
+        );
+    });
+
+    it('should abort analytics call after 5 seconds', async () => {
+        jest.useFakeTimers();
+
+        const integration = createMockIntegration();
+        integration.quo.api.sendAnalyticsEvent.mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    setTimeout(() => resolve({ ok: true }), 60_000);
+                })
+        );
+
+        const trackPromise = trackAnalyticsEvent(integration, 'ContactUpdated');
+
+        await jest.advanceTimersByTimeAsync(5_000);
+        await trackPromise;
+
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('timed out')
+        );
+
+        jest.useRealTimers();
+    });
+
+    it('should succeed when analytics responds within timeout', async () => {
+        jest.useFakeTimers();
+
+        const integration = createMockIntegration();
+        integration.quo.api.sendAnalyticsEvent.mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    setTimeout(() => resolve({ ok: true }), 1_000);
+                })
+        );
+
+        const trackPromise = trackAnalyticsEvent(integration, 'ContactUpdated');
+
+        await jest.advanceTimersByTimeAsync(1_000);
+        await trackPromise;
+
+        expect(logSpy).toHaveBeenCalledWith(
+            expect.stringContaining('Tracked ContactUpdated')
+        );
+        expect(warnSpy).not.toHaveBeenCalledWith(
+            expect.stringContaining('timed out')
+        );
+
+        jest.useRealTimers();
+    });
+});


### PR DESCRIPTION
## Summary

- Adds a 5-second timeout (`Promise.race`) to the `trackAnalyticsEvent` utility to prevent analytics API outages from blocking Lambda execution
- When the analytics endpoint (`integration.openphoneapi.com/v2/analytics`) returned 502 Bad Gateway on 2026-04-20 ~02:35-03:35 UTC, **383 Lambda invocations hung for 287-289 seconds** (near the 300s Lambda limit), degrading SQS queue throughput across attio, pipedrive, and zoho workers
- Analytics tracking is non-critical (errors already logged as WARN) — a 5s timeout with fail-fast is the correct behavior
- Adds comprehensive test coverage for `trackAnalyticsEvent` (6 tests including timeout scenarios)

## Root Cause

`trackAnalyticsEvent` awaits `sendAnalyticsEvent` with no timeout. When the analytics API hangs, the entire Lambda invocation hangs until the HTTP socket times out (~289s), just inside the 300s Lambda limit.

## Changes

- `backend/src/utils/trackAnalyticsEvent.js`: Wrap `sendAnalyticsEvent` in `Promise.race` with a 5s timeout; clean up timer on completion
- `backend/src/utils/trackAnalyticsEvent.test.js`: New test file with 6 tests covering happy path, skip conditions, error handling, timeout abort, and within-timeout success

## Test plan

- [x] All 6 new unit tests pass (including fake-timer timeout scenarios)
- [x] Full test suite shows no regressions (all failures are pre-existing)
- [x] Prettier formatting verified
- [ ] Deploy to dev and verify analytics tracking still works under normal conditions
- [ ] Verify timeout triggers correctly when analytics endpoint is slow

🤖 Generated with [Claude Code](https://claude.com/claude-code)