### PR TITLE
feat(queue): inspect SendMessageBatch.Failed[] + correlated logs

### DIFF
--- a/.changeset/local-queuer-partial-failure-logs.md
+++ b/.changeset/local-queuer-partial-failure-logs.md
@@ -1,0 +1,9 @@
+---
+'quo-integrations-frigg': patch
+---
+
+Add `SendMessageBatchResult.Failed[]` inspection + structured success logging to `backend/src/base/services/QueuerUtilWrapper.js`. This is the queue-send code path actually used by all CRM sync chains (BaseCRMIntegration routes through the local wrapper, not Frigg core's `QueuerUtil`).
+
+Without this, AWS `SendMessageBatch` can succeed at the HTTP level while silently rejecting individual entries — producing the exact failure mode we observed on Attio integration 800 today: the 17th (cursor=800) FETCH_PERSON_PAGE message was enqueued per Frigg logs, but no Lambda ever received it, the DLQ stayed empty, and there was no trace of what happened. Now every batch send emits either `[QueuerUtilWrapper] SendMessageBatch ok: N/M to <queue>` with per-entry `MessageId + event + processId + integrationId`, or `[QueuerUtilWrapper] SendMessageBatch partial failure: N/M failed` with AWS's `Code`/`Message` plus the same correlation context pulled from the MessageBody. The single-send path also logs `SendMessage ok: MessageId=... to <queue>`.
+
+No control-flow changes beyond logging. Follow-up to Frigg PR #578 — same logic mirrored into the local wrapper so it fires on the code path `BaseCRMIntegration._createQueueManager` uses today.

--- a/backend/src/base/services/QueuerUtilWrapper.js
+++ b/backend/src/base/services/QueuerUtilWrapper.js
@@ -50,6 +50,77 @@ const awsConfigOptions = () => {
 
 const sqs = new SQSClient(awsConfigOptions());
 
+// Best-effort extraction of the logical event/processId/integrationId from a
+// JSON SQS message body. Used only for log correlation — never throws.
+const summarizeMessageBody = (bodyStr) => {
+    try {
+        const parsed = JSON.parse(bodyStr);
+        return {
+            event: parsed?.event,
+            processId: parsed?.data?.processId,
+            integrationId: parsed?.data?.integrationId,
+        };
+    } catch {
+        return {};
+    }
+};
+
+// Inspect SendMessageBatchResult for partial failures and log them.
+//
+// AWS SendMessageBatch can succeed at the HTTP level (2xx) while rejecting
+// individual entries — KMS errors, per-entry throttling, service errors. Callers
+// that don't inspect `result.Failed` silently lose those messages. This was a
+// real production incident in this codebase: cursor=800 FETCH_PERSON_PAGE
+// messages disappeared with no DLQ, no Lambda invocation, no trace. The Frigg
+// framework's queuer-util has the same gap upstream (observability logs added
+// in frigg PR #578) — this mirror makes sure the local wrapper is equally loud.
+const inspectBatchResult = (result, queueUrl, buffer) => {
+    const bufferSize = buffer.length;
+    const failedCount = result?.Failed?.length ?? 0;
+    const successCount = result?.Successful?.length ?? 0;
+
+    const bufferById = new Map(buffer.map((b) => [b.Id, b]));
+
+    if (failedCount > 0) {
+        console.error(
+            `[QueuerUtilWrapper] SendMessageBatch partial failure: ${failedCount}/${bufferSize} failed`,
+            {
+                queueUrl,
+                bufferSize,
+                successCount,
+                failedCount,
+                failed: result.Failed.map((f) => {
+                    const bufEntry = bufferById.get(f.Id);
+                    const summary = bufEntry
+                        ? summarizeMessageBody(bufEntry.MessageBody)
+                        : {};
+                    return {
+                        Id: f.Id,
+                        Code: f.Code,
+                        SenderFault: f.SenderFault,
+                        Message: f.Message,
+                        ...summary,
+                    };
+                }),
+            },
+        );
+    } else if (successCount > 0) {
+        const entries = result.Successful.map((s) => {
+            const bufEntry = bufferById.get(s.Id);
+            const summary = bufEntry
+                ? summarizeMessageBody(bufEntry.MessageBody)
+                : {};
+            return { MessageId: s.MessageId, ...summary };
+        });
+        console.log(
+            `[QueuerUtilWrapper] SendMessageBatch ok: ${successCount}/${bufferSize} to ${queueUrl}`,
+            { entries },
+        );
+    }
+
+    return result;
+};
+
 /**
  * Enhanced QueuerUtil with delay support
  *
@@ -78,7 +149,11 @@ const QueuerUtilWrapper = {
         }
 
         const command = new SendMessageCommand(params);
-        return sqs.send(command);
+        const result = await sqs.send(command);
+        console.log(
+            `[QueuerUtilWrapper] SendMessage ok: MessageId=${result?.MessageId} to ${queueUrl}`,
+        );
+        return result;
     },
 
     /**
@@ -130,7 +205,8 @@ const QueuerUtilWrapper = {
                     Entries: buffer,
                     QueueUrl: queueUrl,
                 });
-                await sqs.send(command);
+                const result = await sqs.send(command);
+                inspectBatchResult(result, queueUrl, buffer);
                 // Clear buffer after successful send
                 buffer.splice(0, buffer.length);
             }
@@ -145,7 +221,8 @@ const QueuerUtilWrapper = {
                 Entries: buffer,
                 QueueUrl: queueUrl,
             });
-            return sqs.send(command);
+            const result = await sqs.send(command);
+            return inspectBatchResult(result, queueUrl, buffer);
         }
 
         // No messages to send


### PR DESCRIPTION
Adds partial-failure detection and structured logs to the local SQS wrapper (`backend/src/base/services/QueuerUtilWrapper.js`), which is the queue-send code path actually used by every CRM sync chain (BaseCRMIntegration wires `QueueManager` to this local wrapper, not to Frigg core's QueuerUtil).

Motivation: today's investigation of Attio integration 800 reproduced a stuck-sync where the 17th FETCH_PERSON_PAGE SQS message (cursor=800) disappeared — logged as sent by the wrapper, never delivered to Lambda, never in DLQ. The AWS SDK call `sqs.send(SendMessageBatchCommand)` can resolve successfully while rejecting individual entries (`result.Failed[]`) — the previous code ignored that return value, so we had no signal.

Added:
- `inspectBatchResult()`: on every SendMessageBatch, logs either `[QueuerUtilWrapper] SendMessageBatch ok: N/M to <queue>` with per-entry `{MessageId, event, processId, integrationId}` summary, or `[QueuerUtilWrapper] SendMessageBatch partial failure: N/M failed` with AWS's `Code`/`Message`/`SenderFault` plus the same correlation context extracted from the MessageBody.
- `summarizeMessageBody()`: defensive JSON parser that returns `{event, processId, integrationId}` or `{}` on parse failure. Never throws.
- Single-send path (`QueuerUtilWrapper.send`): now logs `SendMessage ok: MessageId=... to <queue>` on success.

No control-flow changes: result is still returned unchanged to callers. Mirrors the same logic landed upstream in Frigg PR #578 (the framework-level `@friggframework/core/queues/queuer-util.js`) so we have matching visibility no matter which path is active.