### PR TITLE
fix(base): coerce numeric IDs to strings in ProcessManager

### DIFF
--- a/.changeset/fix-numeric-integration-id.md
+++ b/.changeset/fix-numeric-integration-id.md
@@ -1,0 +1,5 @@
+---
+'quo-integrations-frigg': patch
+---
+
+Coerce `integrationId` and `userId` to strings in `ProcessManager.createSyncProcess()` before passing to Frigg Core's `CreateProcess` use case. PostgreSQL returns numeric IDs which fail the framework's `typeof !== 'string'` validation, breaking initial sync for newly created integrations (observed on integration 800 in prod, 2026-04-20).

--- a/backend/src/base/services/ProcessManager.js
+++ b/backend/src/base/services/ProcessManager.js
@@ -62,8 +62,8 @@ class ProcessManager {
     /**
      * Create a new CRM sync process with appropriate context structure
      * @param {Object} params
-     * @param {string} params.integrationId - Integration ID
-     * @param {string} params.userId - User ID
+     * @param {string|number} params.integrationId - Integration ID (coerced to string)
+     * @param {string|number} params.userId - User ID (coerced to string)
      * @param {string} params.syncType - Type of sync (INITIAL, ONGOING, WEBHOOK)
      * @param {string} params.personObjectType - CRM object type (Contact, Lead, etc.)
      * @param {string} [params.state='INITIALIZING'] - Initial state
@@ -82,6 +82,12 @@ class ProcessManager {
         totalRecords = 0,
         pageSize = 100,
     }) {
+        if (!integrationId || !userId) {
+            throw new Error(
+                `createSyncProcess requires integrationId and userId, got integrationId=${integrationId}, userId=${userId}`,
+            );
+        }
+
         // Frigg Core validates these as strings; coerce for PostgreSQL numeric IDs
         const strIntegrationId = String(integrationId);
         const strUserId = String(userId);

--- a/backend/src/base/services/ProcessManager.js
+++ b/backend/src/base/services/ProcessManager.js
@@ -82,8 +82,11 @@ class ProcessManager {
         totalRecords = 0,
         pageSize = 100,
     }) {
-        // Construct process name
-        const processName = `${integrationId}-${personObjectType}-sync`;
+        // Frigg Core validates these as strings; coerce for PostgreSQL numeric IDs
+        const strIntegrationId = String(integrationId);
+        const strUserId = String(userId);
+
+        const processName = `${strIntegrationId}-${personObjectType}-sync`;
 
         // Build CRM sync context structure
         const context = {
@@ -125,8 +128,8 @@ class ProcessManager {
 
         // Create process via use case
         const process = await this.createProcessUseCase.execute({
-            userId,
-            integrationId,
+            userId: strUserId,
+            integrationId: strIntegrationId,
             name: processName,
             type: 'CRM_SYNC',
             state,

--- a/backend/src/base/services/ProcessManager.test.js
+++ b/backend/src/base/services/ProcessManager.test.js
@@ -126,6 +126,23 @@ describe('ProcessManager', () => {
             );
         });
 
+        it('should coerce numeric integrationId and userId to strings', async () => {
+            const mockProcess = buildProcessRecord();
+            mockCreateProcessUseCase.execute.mockResolvedValue(mockProcess);
+
+            await processManager.createSyncProcess({
+                integrationId: 800,
+                userId: 42,
+                syncType: 'INITIAL',
+                personObjectType: 'Contact',
+            });
+
+            const callArgs = mockCreateProcessUseCase.execute.mock.calls[0][0];
+            expect(callArgs.integrationId).toBe('800');
+            expect(callArgs.userId).toBe('42');
+            expect(callArgs.name).toBe('800-Contact-sync');
+        });
+
         it('should use custom pageSize if provided', async () => {
             const mockProcess = buildProcessRecord();
             mockCreateProcessUseCase.execute.mockResolvedValue(mockProcess);

--- a/backend/src/base/services/ProcessManager.test.js
+++ b/backend/src/base/services/ProcessManager.test.js
@@ -143,6 +143,26 @@ describe('ProcessManager', () => {
             expect(callArgs.name).toBe('800-Contact-sync');
         });
 
+        it('should throw when integrationId or userId is missing', async () => {
+            await expect(
+                processManager.createSyncProcess({
+                    integrationId: undefined,
+                    userId: 'user-456',
+                    syncType: 'INITIAL',
+                    personObjectType: 'Contact',
+                }),
+            ).rejects.toThrow('createSyncProcess requires integrationId and userId');
+
+            await expect(
+                processManager.createSyncProcess({
+                    integrationId: 'integration-123',
+                    userId: null,
+                    syncType: 'INITIAL',
+                    personObjectType: 'Contact',
+                }),
+            ).rejects.toThrow('createSyncProcess requires integrationId and userId');
+        });
+
         it('should use custom pageSize if provided', async () => {
             const mockProcess = buildProcessRecord();
             mockCreateProcessUseCase.execute.mockResolvedValue(mockProcess);


### PR DESCRIPTION
## Summary

- Coerce `integrationId` and `userId` to strings in `ProcessManager.createSyncProcess()` before passing to Frigg Core's `CreateProcess` use case
- PostgreSQL returns numeric IDs (e.g., `800`) which fail the framework's `typeof !== 'string'` validation at `create-process.js:98`
- This broke initial sync for newly created integrations — observed on **integration 800** (Attio) in prod on 2026-04-20 at 14:38 UTC

## Root Cause

The flow: `onCreate({ integrationId: 800 })` → queue message → `handlePostCreateSetup` → `startInitialSync` → `SyncOrchestrator.startInitialSync` → `ProcessManager.createSyncProcess` → Frigg Core `CreateProcess._validateProcessData` → **throws "integrationId must be a string"**

The fix is at the `ProcessManager` boundary (single choke point before the framework), protecting all callers: `SyncOrchestrator.startInitialSync`, `startOngoingSync`, `handleWebhook`, and AxisCare's direct calls.

## Test plan

- [x] Added test: numeric `integrationId` (800) and `userId` (42) are coerced to strings before reaching the use case
- [x] Verified existing string IDs are preserved unchanged
- [ ] Verify in dev: trigger a new integration creation and confirm initial sync starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)